### PR TITLE
Add button combination mappping suppor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -739,7 +739,7 @@ if(NOT LIBRETRO AND NOT NINTENDO_SWITCH)
 	target_include_directories(${PROJECT_NAME} PRIVATE core/deps/websocketpp)
 	target_compile_definitions(${PROJECT_NAME} PRIVATE ASIO_STANDALONE)
 	if (MSVC)
-		target_compile_definitions(${PROJECT_NAME} PRIVATE 
+		target_compile_definitions(${PROJECT_NAME} PRIVATE
 			_WEBSOCKETPP_CPP11_FUNCTIONAL_
 			_WEBSOCKETPP_CPP11_SYSTEM_ERROR_
 			_WEBSOCKETPP_CPP11_RANDOM_DEVICE_
@@ -1945,6 +1945,7 @@ if(BUILD_TESTING)
 	add_subdirectory(core/deps/googletest EXCLUDE_FROM_ALL)
 	target_link_libraries(${PROJECT_NAME} PRIVATE GTest::gtest_main)
 
+	target_include_directories(${PROJECT_NAME} PUBLIC tests/inc)
 	target_sources(${PROJECT_NAME} PRIVATE
 			tests/src/CheatManagerTest.cpp
 			tests/src/ConfigFileTest.cpp
@@ -1954,6 +1955,12 @@ if(BUILD_TESTING)
 			tests/src/AicaArmTest.cpp
 			tests/src/Sh4InterpreterTest.cpp
 			tests/src/MmuTest.cpp
+			tests/src/input/ButtonComboTest.cpp
+			tests/src/input/GamepadInputHandlingTest.cpp
+			tests/src/input/MultiBindMappingTest.cpp
+			tests/src/input/InputDefTest.cpp
+			tests/src/input/InputMappingConfigFileTest.cpp
+			tests/src/input/InputSetTest.cpp
 			tests/src/util/PeriodicThreadTest.cpp
 			tests/src/util/TsQueueTest.cpp
 			tests/src/util/WorkerThreadTest.cpp)

--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -267,16 +267,19 @@ bool GamepadDevice::gamepad_axis_input(u32 code, int value)
 	{
 		if (_detecting_axis && std::abs(value) >= 16384)
 		{
-			_input_detected(code, true, positive);
-
 			// If we're in combo detection mode, add this axis to tracking but don't end detection
 			if (_detecting_combo)
 			{
 				// Track this axis as a "button" for combo detection
-				detectionInputs.insert_back(inputDef);
+				if (detectionInputs.insert_back(inputDef))
+				{
+					_input_detected(code, true, positive);
+				}
+
 				return true;
 			}
 
+			_input_detected(code, true, positive);
 			_input_detected = nullptr;
 			return true;
 		}

--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -210,7 +210,7 @@ bool GamepadDevice::handleButtonInputDef(const InputMapping::InputDef& inputDef,
 
 bool GamepadDevice::gamepad_btn_input(u32 code, bool pressed)
 {
-	InputMapping::InputDef inputDef{code, InputMapping::InputDef::InputType::BUTTON};
+	const InputMapping::InputDef inputDef = InputMapping::InputDef::from_button(code);
 
 	// When detecting input for button mapping
 	if (_input_detected != nullptr && _detecting_button
@@ -269,11 +269,9 @@ static DreamcastKey getOppositeAxis(DreamcastKey key)
 //
 bool GamepadDevice::gamepad_axis_input(u32 code, int value)
 {
-	bool positive = value >= 0;
-	InputMapping::InputDef inputDef{
-		code,
-		(positive ? InputMapping::InputDef::InputType::AXIS_POS : InputMapping::InputDef::InputType::AXIS_NEG)
-	};
+	const bool positive = value >= 0;
+	const InputMapping::InputDef inputDef = InputMapping::InputDef::from_axis(code, positive);
+	const InputMapping::InputDef inverseInputDef = InputMapping::InputDef::from_axis(code, !positive);
 
 	if (_input_detected != NULL & getTimeMs() >= _detection_start_time)
 	{
@@ -465,6 +463,8 @@ bool GamepadDevice::gamepad_axis_input(u32 code, int value)
 	const int absValue = std::abs(value);
 	if (absValue < AXIS_DEACTIVATION_VALUE || absValue >= AXIS_ACTIVATION_VALUE)
 	{
+		// Reset opposite axis to 0
+		rc = handleButtonInputDef(inverseInputDef, false) || rc;
 		rc = handleButtonInputDef(inputDef, (absValue >= AXIS_ACTIVATION_VALUE)) || rc;
 	}
 

--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -168,25 +168,27 @@ bool GamepadDevice::handleButtonInputDef(const InputMapping::InputDef& inputDef,
 	if (pressed)
 	{
 		// Add to triggered inputs
-		currentInputs.insert_back(inputDef);
-
-		// Handle keys activated by this new input
-		mappedKeys = input_mapper->get_button_ids(targetPort, currentInputs);
-		for (const DreamcastKey& key : mappedKeys)
+		if (currentInputs.insert_back(inputDef))
 		{
-			currentKeys.push_back(key);
+			// Handle keys activated by this new input
+			mappedKeys = input_mapper->get_button_ids(targetPort, currentInputs);
+			for (const DreamcastKey& key : mappedKeys)
+			{
+				currentKeys.push_back(key);
+			}
 		}
 	}
 	else
 	{
 		// Remove from triggered inputs
-		currentInputs.remove(inputDef);
-
-		// Handle keys deactivated by this new input
-		mappedKeys = input_mapper->get_button_released_ids(targetPort, currentKeys, inputDef);
-		for (const DreamcastKey& key : mappedKeys)
+		if (currentInputs.remove(inputDef) > 0)
 		{
-			currentKeys.remove(key);
+			// Handle keys deactivated by this new input
+			mappedKeys = input_mapper->get_button_released_ids(targetPort, currentKeys, inputDef);
+			for (const DreamcastKey& key : mappedKeys)
+			{
+				currentKeys.remove(key);
+			}
 		}
 	}
 
@@ -456,7 +458,7 @@ bool GamepadDevice::gamepad_axis_input(u32 code, int value)
 		// Reset opposite axis to 0
 		handle_axis(_maple_port, key, 0);
 		key = input_mapper->get_axis_id(0, code, positive);
-		rc = handle_axis(_maple_port, key, value) || rc;
+		rc = handle_axis(_maple_port, key, value);
 	}
 
 	// Update axis press tracking for button combinations

--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -196,9 +196,9 @@ bool GamepadDevice::gamepad_btn_input(u32 code, bool pressed)
 	if (pressed)
 	{
 		// Add to triggered inputs
-		currentInputs[targetPort].insert_back(inputDef);
+		currentInputs.insert_back(inputDef);
 		// Handle keys activated by this new input
-		std::list<DreamcastKey> keys = input_mapper->get_combo_ids(targetPort, currentInputs[targetPort]);
+		std::list<DreamcastKey> keys = input_mapper->get_combo_ids(targetPort, currentInputs);
 		for (const DreamcastKey& key : keys)
 		{
 			if (_maple_port == 4)
@@ -215,7 +215,7 @@ bool GamepadDevice::gamepad_btn_input(u32 code, bool pressed)
 	else
 	{
 		// Remove from triggered inputs
-		currentInputs[targetPort].remove(inputDef);
+		currentInputs.remove(inputDef);
 		DreamcastKey key = input_mapper->get_button_id(targetPort, code);
 		if (_maple_port == 4)
 		{
@@ -303,11 +303,11 @@ bool GamepadDevice::gamepad_axis_input(u32 code, int value)
 	// We consider an axis "pressed" if its value exceeds a threshold
 	if (std::abs(value) >= 16384) // Use 50% deflection as "pressed" threshold
 	{
-		pressed = currentInputs[targetPort].insert_back(inputDef);
+		pressed = currentInputs.insert_back(inputDef);
 	}
 	else if (std::abs(value) < 8192) // Use 25% deflection as "released" threshold
 	{
-		currentInputs[targetPort].remove(inputDef);
+		currentInputs.remove(inputDef);
 	}
 
 	auto handle_axis = [&](u32 port, DreamcastKey key, int v)
@@ -452,7 +452,7 @@ bool GamepadDevice::gamepad_axis_input(u32 code, int value)
 
 			if (pressed)
 			{
-				std::list<DreamcastKey> keys = input_mapper->get_combo_ids(port, currentInputs[targetPort]);
+				std::list<DreamcastKey> keys = input_mapper->get_combo_ids(port, currentInputs);
 				for (const DreamcastKey& otherKey : keys)
 				{
 					if (otherKey != key)
@@ -471,7 +471,7 @@ bool GamepadDevice::gamepad_axis_input(u32 code, int value)
 
 		if (pressed)
 		{
-			std::list<DreamcastKey> keys = input_mapper->get_combo_ids(0, currentInputs[targetPort]);
+			std::list<DreamcastKey> keys = input_mapper->get_combo_ids(0, currentInputs);
 			for (const DreamcastKey& otherKey : keys)
 			{
 				if (otherKey != key)

--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -163,7 +163,7 @@ bool GamepadDevice::handleButtonInputDef(const InputMapping::InputDef& inputDef,
 	// Update button press tracking
 	int targetPort = (_maple_port == 4) ? 0 : _maple_port; // Use port 0 for all-ports mode as a base
 
-	std::list<DreamcastKey> mappedKeys;
+	DreamcastKey mappedKey = EMU_BTN_NONE;
 
 	if (pressed)
 	{
@@ -171,10 +171,10 @@ bool GamepadDevice::handleButtonInputDef(const InputMapping::InputDef& inputDef,
 		if (currentInputs.insert_back(inputDef))
 		{
 			// Handle keys activated by this new input
-			mappedKeys = input_mapper->get_button_ids(targetPort, currentInputs);
-			for (const DreamcastKey& key : mappedKeys)
+			mappedKey = input_mapper->get_button_id(targetPort, currentInputs);
+			if (mappedKey != EMU_BTN_NONE)
 			{
-				currentKeys.push_back(key);
+				currentKeys.push_back(mappedKey);
 			}
 		}
 	}
@@ -184,24 +184,21 @@ bool GamepadDevice::handleButtonInputDef(const InputMapping::InputDef& inputDef,
 		if (currentInputs.remove(inputDef) > 0)
 		{
 			// Handle keys deactivated by this new input
-			mappedKeys = input_mapper->get_button_released_ids(targetPort, currentKeys, inputDef);
-			for (const DreamcastKey& key : mappedKeys)
-			{
-				currentKeys.remove(key);
-			}
+			mappedKey = input_mapper->get_button_released_id(targetPort, currentKeys, inputDef);
+			currentKeys.remove(mappedKey);
 		}
 	}
 
-	for (const DreamcastKey& key : mappedKeys)
+	if (mappedKey != EMU_BTN_NONE)
 	{
 		if (_maple_port == 4)
 		{
 			for (int port = 0; port < 4; port++)
-				rc = handleButtonInput(port, key, pressed) || rc;
+				rc = handleButtonInput(port, mappedKey, pressed) || rc;
 		}
 		else
 		{
-			rc = handleButtonInput(_maple_port, key, pressed);
+			rc = handleButtonInput(_maple_port, mappedKey, pressed);
 		}
 	}
 

--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -163,7 +163,7 @@ bool GamepadDevice::handleButtonInputDef(const InputMapping::InputDef& inputDef,
 	// Update button press tracking
 	int targetPort = (_maple_port == 4) ? 0 : _maple_port; // Use port 0 for all-ports mode as a base
 
-	DreamcastKey mappedKey = EMU_BTN_NONE;
+	std::list<DreamcastKey> mappedKeys;
 
 	if (pressed)
 	{
@@ -171,9 +171,10 @@ bool GamepadDevice::handleButtonInputDef(const InputMapping::InputDef& inputDef,
 		if (currentInputs.insert_back(inputDef))
 		{
 			// Handle keys activated by this new input
-			mappedKey = input_mapper->get_button_id(targetPort, currentInputs);
+			DreamcastKey mappedKey = input_mapper->get_button_id(targetPort, currentInputs);
 			if (mappedKey != EMU_BTN_NONE)
 			{
+				mappedKeys.push_back(mappedKey);
 				currentKeys.push_back(mappedKey);
 			}
 		}
@@ -184,12 +185,15 @@ bool GamepadDevice::handleButtonInputDef(const InputMapping::InputDef& inputDef,
 		if (currentInputs.remove(inputDef) > 0)
 		{
 			// Handle keys deactivated by this new input
-			mappedKey = input_mapper->get_button_released_id(targetPort, currentKeys, inputDef);
-			currentKeys.remove(mappedKey);
+			mappedKeys = input_mapper->get_button_released_ids(targetPort, currentKeys, inputDef);
+			for (const DreamcastKey& mappedKey : mappedKeys)
+			{
+				currentKeys.remove(mappedKey);
+			}
 		}
 	}
 
-	if (mappedKey != EMU_BTN_NONE)
+	for (const DreamcastKey& mappedKey : mappedKeys)
 	{
 		if (_maple_port == 4)
 		{

--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -599,30 +599,30 @@ static void updateVibration(u32 port, float power, float inclination, u32 durati
 
 void GamepadDevice::detect_btn_input(input_detected_cb button_pressed)
 {
-	_input_detected = button_pressed;
-	_detecting_button = true;
-	_detecting_axis = false;
-	_detection_start_time = getTimeMs() + 200;
-	detectionInputs.clear();
+	detectInput(true, false, false, button_pressed);
 }
 
 void GamepadDevice::detect_axis_input(input_detected_cb axis_moved)
 {
-	_input_detected = axis_moved;
-	_detecting_button = false;
-	_detecting_axis = true;
-	_detection_start_time = getTimeMs() + 200;
-	detectionInputs.clear();
+	detectInput(false, true, false, axis_moved);
 }
 
 void GamepadDevice::detectButtonOrAxisInput(input_detected_cb input_changed)
 {
-	_input_detected = input_changed;
-	_detecting_button = true;
-	_detecting_axis = true;
-	_detection_start_time = getTimeMs() + 200;
-	_detecting_combo = true;
-	detectionInputs.clear();
+	detectInput(true, true, true, input_changed);
+}
+
+void GamepadDevice::detectInput(bool button, bool axis, bool combo, input_detected_cb input_changed)
+{
+	if (button || axis || combo)
+	{
+		_input_detected = input_changed;
+		_detecting_button = button;
+		_detecting_axis = axis;
+		_detecting_combo = combo;
+		_detection_start_time = getTimeMs() + 200;
+		detectionInputs.clear();
+	}
 }
 
 #ifdef TEST_AUTOMATION

--- a/core/input/gamepad_device.h
+++ b/core/input/gamepad_device.h
@@ -50,7 +50,7 @@ public:
 		_detecting_button = false;
 		_detecting_axis = false;
 		_detecting_combo = false;
-		detectionButtons.clear();
+		detectionInputs.clear();
 	}
 	bool is_input_detecting() const {
 		return _input_detected != nullptr;
@@ -134,7 +134,7 @@ protected:
 	{
 		// Initialize pressedButtons sets
 		for (int i = 0; i < 4; i++)
-			pressedButtons[i].clear();
+			currentInputs[i].clear();
 	}
 
 	void loadMapping() {
@@ -163,11 +163,10 @@ private:
 	bool handleButtonInput(int port, DreamcastKey key, bool pressed);
 	std::string make_mapping_filename(bool instance, int system, bool perGame = false);
 
-	// Track which buttons are currently pressed (for button combos)
-	std::set<u32> pressedButtons[4];
-	// Track buttons pressed during the current mapping session
-	std::set<u32> detectionButtons;
-	bool isButtonCombinationPressed(int port, const InputMapping::ButtonCombination& combo);
+	// Track which inputs are currently activated (for button combos)
+	InputMapping::InputSet currentInputs[4];
+	// Track inputs during the current mapping session
+	InputMapping::InputSet detectionInputs;
 
 	enum DigAnalog {
 		DIGANA_LEFT   = 1 << 0,

--- a/core/input/gamepad_device.h
+++ b/core/input/gamepad_device.h
@@ -50,6 +50,7 @@ public:
 		_detecting_button = false;
 		_detecting_axis = false;
 		_detecting_combo = false;
+		detectionButtons.clear();
 	}
 	std::shared_ptr<InputMapping> get_input_mapping() { return input_mapper; }
 	void save_mapping(int system = settings.platform.system);
@@ -161,6 +162,8 @@ private:
 
 	// Track which buttons are currently pressed (for button combos)
 	std::set<u32> pressedButtons[4];
+	// Track buttons pressed during the current mapping session
+	std::set<u32> detectionButtons;
 	bool isButtonCombinationPressed(int port, const InputMapping::ButtonCombination& combo);
 
 	enum DigAnalog {

--- a/core/input/gamepad_device.h
+++ b/core/input/gamepad_device.h
@@ -127,6 +127,11 @@ public:
 	void setPerGameMapping(bool enabled);
 	bool isPerGameMapping() const { return perGameMapping; }
 
+	//! The axis value which causes a button activation (for axis to button mapping) (inclusive)
+	static const int AXIS_ACTIVATION_VALUE = 16384;  // Use 50% deflection as "pressed" threshold
+	//! The axis value which causes a button deactivation (for axis to button mapping) (exclusive)
+	static const int AXIS_DEACTIVATION_VALUE = 8192; // 25% deflection as "released" threshold
+
 protected:
 	GamepadDevice(int maple_port, const char *api_name, bool remappable = true)
 		: _api_name(api_name), _maple_port(maple_port), _input_detected(nullptr), _remappable(remappable),
@@ -160,12 +165,15 @@ protected:
 private:
 	virtual void registered() {}
 	bool handleButtonInput(int port, DreamcastKey key, bool pressed);
+	bool handleButtonInputDef(const InputMapping::InputDef& inputDef, bool pressed);
 	std::string make_mapping_filename(bool instance, int system, bool perGame = false);
 
 	// Track which inputs are currently activated (for button combos)
 	InputMapping::InputSet currentInputs;
 	// Track inputs during the current mapping session
 	InputMapping::InputSet detectionInputs;
+	// Track which keys are currently pressed
+	std::list<DreamcastKey> currentKeys;
 
 	enum DigAnalog {
 		DIGANA_LEFT   = 1 << 0,

--- a/core/input/gamepad_device.h
+++ b/core/input/gamepad_device.h
@@ -52,6 +52,9 @@ public:
 		_detecting_combo = false;
 		detectionButtons.clear();
 	}
+	bool is_input_detecting() const {
+		return _input_detected != nullptr;
+	}
 	std::shared_ptr<InputMapping> get_input_mapping() { return input_mapper; }
 	void save_mapping(int system = settings.platform.system);
 

--- a/core/input/gamepad_device.h
+++ b/core/input/gamepad_device.h
@@ -133,8 +133,7 @@ protected:
 		  digitalToAnalogState{}
 	{
 		// Initialize pressedButtons sets
-		for (int i = 0; i < 4; i++)
-			currentInputs[i].clear();
+		currentInputs.clear();
 	}
 
 	void loadMapping() {
@@ -164,7 +163,7 @@ private:
 	std::string make_mapping_filename(bool instance, int system, bool perGame = false);
 
 	// Track which inputs are currently activated (for button combos)
-	InputMapping::InputSet currentInputs[4];
+	InputMapping::InputSet currentInputs;
 	// Track inputs during the current mapping session
 	InputMapping::InputSet detectionInputs;
 

--- a/core/input/gamepad_device.h
+++ b/core/input/gamepad_device.h
@@ -45,6 +45,7 @@ public:
 	void detect_btn_input(input_detected_cb button_pressed);
 	void detect_axis_input(input_detected_cb axis_moved);
 	void detectButtonOrAxisInput(input_detected_cb input_changed);
+	void detectInput(bool button, bool axis, bool combo, input_detected_cb input_changed);
 	void cancel_detect_input() {
 		_input_detected = nullptr;
 		_detecting_button = false;

--- a/core/input/mapping.cpp
+++ b/core/input/mapping.cpp
@@ -518,7 +518,7 @@ bool InputMapping::save(const std::string& name)
 	mf.set_int("emulator", "dead_zone", (int)std::round(this->dead_zone * 100.f));
 	mf.set_int("emulator", "saturation", (int)std::round(this->saturation * 100.f));
 	mf.set_int("emulator", "rumble_power", this->rumblePower);
-	mf.set_int("emulator", "version", 4);  // Update version to support button combos
+	mf.set_int("emulator", "version", 4);  // Updated version to support button combos
 
 	int bindIndex = 0;
 	for (int port = 0; port < 4; port++)

--- a/core/input/mapping.cpp
+++ b/core/input/mapping.cpp
@@ -674,7 +674,7 @@ DreamcastKey InputMapping::get_button_released_id(
 	const std::multimap<DreamcastKey, ButtonCombo>& inputMap = reverseButtonMap[port];
 	for (const DreamcastKey& key : activeKeys)
 	{
-		auto& range = inputMap.equal_range(key);
+		const auto& range = inputMap.equal_range(key);
 		for(auto iter = range.first; iter != range.second; ++iter)
 		{
 			if (iter->second.inputs.contains(releasedInput))
@@ -699,7 +699,7 @@ void InputMapping::clear_button(u32 port, DreamcastKey id)
 	std::multimap<DreamcastKey, ButtonCombo>& revInputMap = reverseButtonMap[port];
 
 	// Remove the existing
-	auto& range = revInputMap.equal_range(id);
+	const auto& range = revInputMap.equal_range(id);
 	for(auto existing = range.first; existing != range.second;)
 	{
 		inputMap.erase(existing->second);
@@ -772,7 +772,7 @@ u32 InputMapping::get_button_code(u32 port, DreamcastKey key) const
 	}
 
 	const std::multimap<DreamcastKey, ButtonCombo>& inputMap = reverseButtonMap[port];
-	auto& range = inputMap.equal_range(key);
+	const auto& range = inputMap.equal_range(key);
 	for(auto iter = range.first; iter != range.second; ++iter)
 	{
 		if (iter->second.inputs.size() == 1 && iter->second.inputs.begin()->is_button())

--- a/core/input/mapping.cpp
+++ b/core/input/mapping.cpp
@@ -141,7 +141,7 @@ bool InputMapping::InputDef::operator==(const InputDef& rhs) const
 
 bool InputMapping::InputDef::operator!=(const InputDef& rhs) const
 {
-	return (get_hash() != rhs.get_hash());
+	return !(*this == rhs);
 }
 
 bool InputMapping::InputDef::is_button() const
@@ -337,16 +337,28 @@ bool InputMapping::ButtonCombo::operator<(const ButtonCombo& rhs) const
 	return inputs < rhs.inputs;
 }
 
+bool InputMapping::ButtonCombo::operator==(const ButtonCombo& rhs) const
+{
+	return (inputs == rhs.inputs && sequential == rhs.sequential);
+}
+
+bool InputMapping::ButtonCombo::operator!=(const ButtonCombo& rhs) const
+{
+	return !(*this == rhs);
+}
+
 bool InputMapping::ButtonCombo::intersects(const ButtonCombo& rhs) const
 {
 	if (!sequential || !rhs.sequential)
 	{
-		if (inputs.ends_with(rhs.inputs, false) && rhs.inputs.ends_with(inputs, false))
-		{
-			return true;
-		}
+		// Return true iff both sets contain the same elements
+		return (inputs.size() == rhs.inputs.size() && inputs.ends_with(rhs.inputs, false));
 	}
-	return false;
+	else
+	{
+		// Return true iff exactly matching
+		return *this == rhs;
+	}
 }
 
 //

--- a/core/input/mapping.cpp
+++ b/core/input/mapping.cpp
@@ -487,6 +487,13 @@ void InputMapping::load(FILE* fp)
 				WARN_LOG(INPUT, "Invalid bind entry: %s", s.c_str());
 				break;
 			}
+			int port = 0;
+			if (key[key.size() - 1] >= '1' && key[key.size() - 1] <= '3')
+			{
+				port = key[key.size() - 1] - '0';
+				key = key.substr(0, key.size() - 1);
+			}
+			DreamcastKey id = getKeyId(key);
 			bool sequential = true;
 			if (parts.size() > 2)
 			{
@@ -500,13 +507,6 @@ void InputMapping::load(FILE* fp)
 					sequential = true;
 				}
 			}
-			int port = 0;
-			if (key[key.size() - 1] >= '1' && key[key.size() - 1] <= '3')
-			{
-				port = key[key.size() - 1] - '0';
-				key = key.substr(0, key.size() - 1);
-			}
-			DreamcastKey id = getKeyId(key);
 			set_button(port, id, ButtonCombo{inputs, sequential});
 		}
 	}

--- a/core/input/mapping.cpp
+++ b/core/input/mapping.cpp
@@ -876,7 +876,7 @@ bool InputMapping::save(const std::string& name)
 	{
 		for (const auto& pair : multiEmuButtonMap[port])
 		{
-			if (pair.second.inputs.size() != 1 || !pair.second.inputs.begin()->is_button())
+			if (pair.second.inputs.size() != 1)
 				continue;
 			if (pair.first == EMU_BTN_NONE)
 				continue;
@@ -918,7 +918,7 @@ bool InputMapping::save(const std::string& name)
 		for (const auto& pair : multiEmuButtonMap[port])
 		{
 			if (pair.second.inputs.size() == 1)
-				continue; // Already covered above
+				continue; // Already covered by digital bind
 			if (pair.first == EMU_BTN_NONE)
 				continue;
 			const char *keyName = getKeyName(pair.first);

--- a/core/input/mapping.cpp
+++ b/core/input/mapping.cpp
@@ -763,26 +763,6 @@ u32 InputMapping::get_button_code(u32 port, DreamcastKey key) const
 	return InputDef::INVALID_CODE;
 }
 
-InputMapping::ButtonCombo* InputMapping::get_button_ptr(u32 port, DreamcastKey key)
-{
-	if (port >= NUM_PORTS)
-	{
-		// Invalid port
-		return nullptr;
-	}
-
-	std::map<DreamcastKey, ButtonCombo>& inputMap = multiEmuButtonMap[port];
-	std::map<DreamcastKey, ButtonCombo>::iterator iter = inputMap.find(key);
-
-	if (iter != inputMap.end())
-	{
-		return &(iter->second);
-	}
-
-	// Not found
-	return nullptr;
-}
-
 void InputMapping::ClearMappings()
 {
 	loaded_mappings.clear();

--- a/core/input/mapping.cpp
+++ b/core/input/mapping.cpp
@@ -462,6 +462,8 @@ void InputMapping::load(FILE* fp)
 			std::string s = mf.get("combo", "bind" + std::to_string(bindIndex++), "");
 			if (s.empty())
 				break;
+			// Parse for 1 more colon than what is needed for forward compatibility
+			// (third colon and everything after it is ignored)
 			std::vector<std::string> parts = strSplit(s, ':', 3);
 			if (parts.size() < 2)
 			{

--- a/core/input/mapping.cpp
+++ b/core/input/mapping.cpp
@@ -660,7 +660,7 @@ DreamcastKey InputMapping::get_button_id(
 	return matchedKey;
 }
 
-DreamcastKey InputMapping::get_button_released_id(
+std::list<DreamcastKey> InputMapping::get_button_released_ids(
 	u32 port,
 	const std::list<DreamcastKey>& activeKeys,
 	const InputDef& releasedInput) const
@@ -668,9 +668,10 @@ DreamcastKey InputMapping::get_button_released_id(
 	if (port >= NUM_PORTS || activeKeys.empty())
 	{
 		// Invalid port or nothing active
-		return EMU_BTN_NONE;
+		return std::list<DreamcastKey>();
 	}
 
+	std::list<DreamcastKey> releasedKeys;
 	const std::multimap<DreamcastKey, ButtonCombo>& inputMap = reverseButtonMap[port];
 	for (const DreamcastKey& key : activeKeys)
 	{
@@ -679,12 +680,12 @@ DreamcastKey InputMapping::get_button_released_id(
 		{
 			if (iter->second.inputs.contains(releasedInput))
 			{
-				return key;
+				releasedKeys.push_back(key);
 			}
 		}
 	}
 
-	return EMU_BTN_NONE;
+	return releasedKeys;
 }
 
 void InputMapping::clear_button(u32 port, DreamcastKey id)

--- a/core/input/mapping.h
+++ b/core/input/mapping.h
@@ -189,7 +189,7 @@ public:
 			return false;
 		}
 
-		//! Insert new element to the back, ensuring uniqueness
+		//! Insert new element to the back only if it doesn't already exist in the set
 		//! @param[in,out] val The value to insert at the back (move operation)
 		inline bool insert_back(InputMapping::InputDef&& val)
 		{

--- a/core/input/mapping.h
+++ b/core/input/mapping.h
@@ -174,20 +174,19 @@ public:
 			}
 		}
 
-		//! Insert new element to the back, ensuring uniqueness
+		//! Insert new element to the back only if it doesn't already exist in the set
 		//! @param[in] val The value to insert at the back
 		//! @return true iff new item inserted
 		inline bool insert_back(const InputMapping::InputDef& val)
 		{
 			remove_inverse_axis(val);
 			const_iterator iter = std::find(cbegin(), cend(), val);
-			bool removed = (iter != cend());
-			if (removed)
+			if (iter == cend())
 			{
-				erase(iter);
+				push_back(val);
+				return true;
 			}
-			push_back(val);
-			return !removed;
+			return false;
 		}
 
 		//! Insert new element to the back, ensuring uniqueness
@@ -196,13 +195,27 @@ public:
 		{
 			remove_inverse_axis(val);
 			const_iterator iter = std::find(cbegin(), cend(), val);
-			bool removed = (iter != cend());
-			if (removed)
+			if (iter == cend())
+			{
+				push_back(std::move(val));
+				return true;
+			}
+			return false;
+		}
+
+		//! Removes all elements that match val
+		//! @param[in] val The value to remove
+		//! @return number of elements removed (normally 0 or 1)
+		inline std::size_t remove(const InputMapping::InputDef& val)
+		{
+			std::size_t removedCount = 0;
+			const_iterator iter;
+			while ((iter = std::find(cbegin(), cend(), val)) != cend())
 			{
 				erase(iter);
+				++removedCount;
 			}
-			push_back(std::move(val));
-			return !removed;
+			return removedCount;
 		}
 
 		//! @return true iff this set contains the given val

--- a/core/input/mapping.h
+++ b/core/input/mapping.h
@@ -164,7 +164,7 @@ public:
 
 		//! Insert new element to the back, ensuring uniqueness
 		//! @param[in] val The value to insert at the back
-		//! @return true iff new item in
+		//! @return true iff new item inserted
 		inline bool insert_back(const InputMapping::InputDef& val)
 		{
 			remove_inverse_axis(val);

--- a/core/input/mapping.h
+++ b/core/input/mapping.h
@@ -22,9 +22,10 @@
 #include "gamepad.h"
 
 #include <map>
-#include <memory>
 #include <set>
-#include <vector>
+#include <memory>
+#include <list>
+#include <limits>
 
 namespace emucfg {
 struct ConfigFile;
@@ -33,21 +34,206 @@ struct ConfigFile;
 class InputMapping
 {
 public:
-	// Structure to hold a button combination
-	struct ButtonCombination
+	//! Uniquely identifies any input, be it button or axis
+	struct InputDef
 	{
-		std::vector<u32> buttons;
+		//! Enumerates the type of input
+		enum class InputType : u8
+		{
+			BUTTON = 0x00,	//!< Digital button type
+			AXIS_POS,		//!< Axis, positive inclination
+			AXIS_NEG		//!< Axis, negative inclination
+		};
 
-		ButtonCombination() = default;
-		explicit ButtonCombination(u32 singleButton) { buttons.push_back(singleButton); }
-		ButtonCombination(const std::vector<u32>& buttonList) : buttons(buttonList) {}
+		//! Initialized and invalid value for code
+		static const u32 INVALID_CODE = std::numeric_limits<u32>::max();
 
-		bool operator==(const ButtonCombination& other) const {
-			return buttons == other.buttons;
+		//! The unique code for the set type
+		u32 code = INVALID_CODE;
+		//! The type of input
+		InputType type = InputType::BUTTON;
+
+		//! Creates a 1:1 hash which uniquely identifies this input
+		inline u64 get_hash() const
+		{
+			return (static_cast<u64>(type) << 32) | code;
 		}
 
-		bool operator<(const ButtonCombination& other) const {
-			return buttons < other.buttons;
+		//! @return true iff this InputType is less than rhs
+		inline bool operator<(const InputDef& rhs) const
+		{
+			return (get_hash() < rhs.get_hash());
+		}
+
+		//! @return true iff this InputType is equivalent to rhs
+		inline bool operator==(const InputDef& rhs) const
+		{
+			return (get_hash() == rhs.get_hash());
+		}
+
+		//! @return true iff this InputType is not equivalent to rhs
+		inline bool operator!=(const InputDef& rhs) const
+		{
+			return (get_hash() != rhs.get_hash());
+		}
+
+		//! @return true iff this InputType is a button
+		inline bool is_button() const
+		{
+			return (type == InputType::BUTTON);
+		}
+
+		//! @return true iff this InputType is an axis
+		inline bool is_axis() const
+		{
+			return (type == InputType::AXIS_POS || type == InputType::AXIS_NEG);
+		}
+
+		//! @return true iff this input definition is valid
+		inline bool is_valid() const
+		{
+			return (code != INVALID_CODE && (is_button() || is_axis()));
+		}
+
+		//! @return true iff this InputType is an axis, rhs is an axis, and axis codes are equivalent
+		inline bool axis_equivalent(const InputDef& rhs)
+		{
+			return (code == rhs.code && is_axis() && rhs.is_axis());
+		}
+
+		//! @return the string equivalent to this InputDef
+		inline std::string to_str() const
+		{
+			std::string result = std::to_string(code);
+			if (type == InputType::AXIS_POS)
+			{
+				result += "+";
+			}
+			else if (type == InputType::AXIS_NEG)
+			{
+				result += "-";
+			}
+			return result;
+		}
+
+		//! Converts a string to an InputDef
+		static inline InputDef from_str(const std::string& str)
+		{
+			InputDef inputDef;
+			if (!str.empty())
+			{
+				std::string tmp = str;
+				if (tmp.back() == '+')
+				{
+					inputDef.type = InputType::AXIS_POS;
+					tmp.erase(tmp.size() - 1);
+				}
+				else if (tmp.back() == '-')
+				{
+					inputDef.type = InputType::AXIS_NEG;
+					tmp.erase(tmp.size() - 1);
+				}
+				else
+				{
+					inputDef.type = InputType::BUTTON;
+				}
+
+				try
+				{
+					inputDef.code = std::stoul(tmp);
+				}
+				catch (const std::exception&)
+				{
+					inputDef.code = INVALID_CODE;
+				}
+			}
+			return inputDef;
+		}
+	};
+
+	//! A group of inputs used to link to multiple keys to a function.
+	//! This class acts like a set with insertion order maintained.
+	class InputSet : public std::list<InputDef>
+	{
+	public:
+		InputSet() : std::list<InputDef>() {}
+
+		explicit InputSet(const allocator_type& a) : std::list<InputDef>(a) {}
+
+		explicit InputSet(std::initializer_list<value_type> l) : std::list<InputDef>(l) {}
+
+		//! Insert new element to the back, ensuring uniqueness
+		//! @param[in] val The value to insert at the back
+		//! @return true iff new item in
+		inline bool insert_back(const InputMapping::InputDef& val)
+		{
+			remove_inverse_axis(val);
+			const_iterator iter = std::find(cbegin(), cend(), val);
+			bool removed = (iter != cend());
+            if (removed)
+            {
+                erase(iter);
+            }
+			push_back(val);
+            return !removed;
+		}
+
+		//! Insert new element to the back, ensuring uniqueness
+		//! @param[in,out] val The value to insert at the back (move operation)
+		inline bool insert_back(InputMapping::InputDef&& val)
+		{
+			remove_inverse_axis(val);
+			const_iterator iter = std::find(cbegin(), cend(), val);
+			bool removed = (iter != cend());
+            if (removed)
+            {
+                erase(iter);
+            }
+			push_back(std::move(val));
+            return !removed;
+		}
+
+		//! @return true iff this set contains the given val
+		inline bool contains(const InputMapping::InputDef& val) const
+		{
+			return (std::find(cbegin(), cend(), val) != cend());
+		}
+
+		//! @return true if this InputSet ends with the given rhs
+		inline bool ends_with(const InputSet& rhs) const
+		{
+			InputSet::const_reverse_iterator iter = crbegin();
+			InputSet::const_reverse_iterator riter = rhs.crbegin();
+
+			while (iter != crend() && riter != rhs.crend())
+			{
+				if (*iter != *riter)
+				{
+					break;
+				}
+				++iter;
+				++riter;
+			}
+
+			return (riter == rhs.crend());
+		}
+
+	private:
+		// Make push functionality private
+		using std::list<InputDef>::push_back;
+		using std::list<InputDef>::push_front;
+
+		//! Removes inverse axis value if val is an axis
+		void remove_inverse_axis(const InputMapping::InputDef& val)
+		{
+			if (val.is_axis())
+			{
+				InputMapping::InputDef::InputType inversetype(
+					val.type == InputMapping::InputDef::InputType::AXIS_POS
+					? InputMapping::InputDef::InputType::AXIS_NEG
+					: InputMapping::InputDef::InputType::AXIS_POS);
+				remove(InputMapping::InputDef{val.code, inversetype});
+			}
 		}
 	};
 
@@ -59,72 +245,69 @@ public:
 		rumblePower = other.rumblePower;
 		for (int port = 0; port < 4; port++)
 		{
-			buttonCombinations[port] = other.buttonCombinations[port];
-			reverseButtonMap[port] = other.reverseButtonMap[port];
-			axes[port] = other.axes[port];
+			multiEmuButtonMap[port] = other.multiEmuButtonMap[port];
+			reverseMultiEmuButtonMap[port] = other.reverseMultiEmuButtonMap[port];
 		}
 	}
+
+	//! Number of controller ports there are
+	static constexpr const u32 NUM_PORTS = 4;
+	//! Version 4 adds button combos
+    static constexpr const int CURRENT_FILE_VERSION = 4;
 
 	std::string name;
 	float dead_zone = 0.1f;
 	float saturation = 1.0f;
 	int rumblePower = 100;
-	int version = 3;
+	int version = CURRENT_FILE_VERSION;
 
 	DreamcastKey get_button_id(u32 port, u32 code)
 	{
-		auto it = reverseButtonMap[port].find(code);
-		if (it != reverseButtonMap[port].end())
-		{
-			DreamcastKey key = it->second;
-			// Check if this key is mapped to a combination of buttons
-			auto comboIt = buttonCombinations[port].find(key);
-			if (comboIt != buttonCombinations[port].end() && comboIt->second.buttons.size() > 1)
-			{
-				// If it's a combination with multiple buttons, we need to be careful
-				// Check if this button is ALSO mapped individually to something else
-				for (auto& mapPair : buttonCombinations[port]) {
-					if (mapPair.first != key && // Not the same mapping
-						mapPair.second.buttons.size() == 1 && // Single button mapping
-						mapPair.second.buttons[0] == code) // For this button
-					{
-						// Found individual mapping - return it instead
-						return mapPair.first;
-					}
-				}
-				
-				// No individual mapping found - don't return anything for individual presses
-				return EMU_BTN_NONE;
-			}
-			return key;
-		}
+		std::list<DreamcastKey> ids = get_combo_ids(port, InputSet{InputDef{code, InputDef::InputType::BUTTON}});
+		if (!ids.empty())
+			return *(ids.begin());
 		else
 			return EMU_BTN_NONE;
 	}
-	
 	void clear_button(u32 port, DreamcastKey id);
 	void set_button(u32 port, DreamcastKey id, u32 code);
-	void set_button_combination(u32 port, DreamcastKey id, const ButtonCombination& combo);
 	void set_button(DreamcastKey id, u32 code) { set_button(0, id, code); }
-	
-	// Get all button codes for a DreamcastKey
-	ButtonCombination get_button_combination(u32 port, DreamcastKey key);
-	// Get the first button code for a DreamcastKey (for backward compatibility)
 	u32 get_button_code(u32 port, DreamcastKey key);
-	// Get all button combination mappings for a port
-	const std::map<DreamcastKey, ButtonCombination>& get_all_button_combinations(u32 port) const {
-		return buttonCombinations[port];
-	}
 
 	DreamcastKey get_axis_id(u32 port, u32 code, bool pos)
 	{
-		auto it = axes[port].find(std::make_pair(code, pos));
-		if (it != axes[port].end())
-			return it->second;
+		InputDef::InputType type = (pos ? InputDef::InputType::AXIS_POS : InputDef::InputType::AXIS_NEG);
+		std::list<DreamcastKey> ids = get_combo_ids(port, InputSet{InputDef{code, type}});
+		if (!ids.empty())
+			return *(ids.begin());
 		else
-			return EMU_AXIS_NONE;
+			return EMU_BTN_NONE;
 	}
 	std::pair<u32, bool> get_axis_code(u32 port, DreamcastKey key);
+
+	//! Resolves existing inputs plus a new input into a key from multi-input lookup
+	//! @param[in] port The port that the given inputs belong to [0,NUM_PORTS)
+	//! @param[in] inputSet The input set to look for
+	//! @return all keys that should be activated due to the new input (all combos this set ends with)
+	std::list<DreamcastKey> get_combo_ids(u32 port, const InputSet& inputSet) const;
+
+	//! Clears combo setting for a given key
+	//! @param[in] port The port [0,NUM_PORTS)
+	//! @param[in] id The key
+	void clear_combo(u32 port, DreamcastKey id);
+
+	//! Sets DreamcastKey to a set of inputs
+	//! @param[in] port The port that the id should be mapped [0,NUM_PORTS)
+	//! @param[in] id The key to map
+	//! @param[in] combo Combination of inputs that should activate the key
+	//! @return true iff the combo has been set
+	bool set_combo(u32 port, DreamcastKey id, const InputSet& combo);
+	inline bool set_combo(DreamcastKey id, const InputSet& combo) { return set_combo(0, id, combo); }
+
+	//! @param[in] port The port [0,NUM_PORTS)
+	//! @param[in] key The key
+	//! @return the InputSet associated with the given key at the given port
+	InputSet get_combo_codes(u32 port, DreamcastKey key);
 
 	void clear_axis(u32 port, DreamcastKey id);
 	void set_axis(u32 port, DreamcastKey id, u32 code, bool positive);
@@ -148,11 +331,10 @@ protected:
 private:
 	void loadv1(emucfg::ConfigFile& mf);
 
-	// Maps a DreamcastKey to a ButtonCombination
-	std::map<DreamcastKey, ButtonCombination> buttonCombinations[4];
-	// Maps a single button code to a DreamcastKey for quick lookups
-	std::map<u32, DreamcastKey> reverseButtonMap[4];
-	std::map<std::pair<u32, bool>, DreamcastKey> axes[4];
+	//! Maps an DreamcastKey to one or more inputs that need to be activated
+	std::map<DreamcastKey, InputSet> multiEmuButtonMap[NUM_PORTS];
+	//! Maps an input to one or more DreamcastKeys which that input is tied to
+	std::multimap<InputDef, DreamcastKey> reverseMultiEmuButtonMap[NUM_PORTS];
 
 	static std::map<std::string, std::shared_ptr<InputMapping>> loaded_mappings;
 };
@@ -163,7 +345,7 @@ public:
 	IdentityInputMapping() {
 		name = "Default";
 		dead_zone = 0.1f;
-		
+
 		for (int i = 0; i < 32; i++)
 			set_button(0, (DreamcastKey)(1 << i), 1 << i);
 		set_button(0, EMU_BTN_FFORWARD, EMU_BTN_FFORWARD);

--- a/core/input/mapping.h
+++ b/core/input/mapping.h
@@ -208,12 +208,6 @@ public:
 	//! @return InputDef::INVALID_CODE if multiple inputs are mapped to this key or none are mapped
 	u32 get_button_code(u32 port, DreamcastKey key) const;
 
-	//! @param[in] port The port [0,NUM_PORTS)
-	//! @param[in] key The key
-	//! @return pointer to the ButtonCombo associated with the given key at the given port if found
-	//! @return nullptr otherwise
-	ButtonCombo* get_button_ptr(u32 port, DreamcastKey key);
-
 	inline DreamcastKey get_axis_id(u32 port, u32 code, bool pos)
 	{
 		auto it = axes[port].find(std::make_pair(code, pos));

--- a/core/input/mapping.h
+++ b/core/input/mapping.h
@@ -260,7 +260,7 @@ private:
 	//! ButtonCombo -> DreamcastKey
 	std::map<ButtonCombo, DreamcastKey> buttonMap[NUM_PORTS];
 	//! DreamcastKey -> ButtonCombo
-	std::map<DreamcastKey, ButtonCombo> reverseButtonMap[NUM_PORTS];
+	std::multimap<DreamcastKey, ButtonCombo> reverseButtonMap[NUM_PORTS];
 
 	static std::map<std::string, std::shared_ptr<InputMapping>> loaded_mappings;
 };

--- a/core/input/mapping.h
+++ b/core/input/mapping.h
@@ -137,6 +137,12 @@ public:
 		//! Set to true if the above input set must be pressed in the given sequence to activate the combo.
 		//! Set to false if all of the buttons may be pressed in any sequence to activate the combo.
 		bool sequential = true;
+
+		//! @return true iff this ButtonCombo is less than rhs
+		bool operator<(const ButtonCombo& rhs) const;
+
+		//! @return true iff this ButtonCombo is equal to or has an intersection with rhs
+		bool intersects(const ButtonCombo& rhs) const;
 	};
 
 	InputMapping() = default;
@@ -147,8 +153,9 @@ public:
 		rumblePower = other.rumblePower;
 		for (int port = 0; port < 4; port++)
 		{
-			multiEmuButtonMap[port] = other.multiEmuButtonMap[port];
-			reverseMultiEmuButtonMap[port] = other.reverseMultiEmuButtonMap[port];
+			axes[port] = other.axes[port];
+			buttonMap[port] = other.buttonMap[port];
+			reverseButtonMap[port] = other.reverseButtonMap[port];
 		}
 	}
 
@@ -167,14 +174,14 @@ public:
 	//! @param[in] port The port that the given inputs belong to [0,NUM_PORTS)
 	//! @param[in] inputSet The input set to look for
 	//! @return all keys that should be activated due to the given input set (all combos inputSet ends with)
-	std::list<DreamcastKey> get_button_ids(u32 port, const InputSet& inputSet) const;
+	DreamcastKey get_button_id(u32 port, const InputSet& inputSet) const;
 
 	//! Resolves currently active keys with a released input into keys that should be released
 	//! @param[in] port The port that the given inputs belong to [0,NUM_PORTS)
-	//! @param[in] activeKeys A list of active keys compiled from get_button_ids()
+	//! @param[in] activeKeys A list of active keys compiled from get_button_id()
 	//! @param[in] releasedInput The released input to check for
 	//! @return all keys that should be released due to the released input
-	std::list<DreamcastKey> get_button_released_ids(
+	DreamcastKey get_button_released_id(
 		u32 port,
 		const std::list<DreamcastKey>& activeKeys,
 		const InputDef& releasedInput) const;
@@ -244,10 +251,10 @@ private:
 
 	std::map<std::pair<u32, bool>, DreamcastKey> axes[NUM_PORTS];
 
-	//! Maps an DreamcastKey to one or more inputs that need to be activated
-	std::map<DreamcastKey, ButtonCombo> multiEmuButtonMap[NUM_PORTS];
-	//! Maps an input to one or more DreamcastKeys which that input is tied to
-	std::multimap<InputDef, DreamcastKey> reverseMultiEmuButtonMap[NUM_PORTS];
+	//! ButtonCombo -> DreamcastKey
+	std::map<ButtonCombo, DreamcastKey> buttonMap[NUM_PORTS];
+	//! DreamcastKey -> ButtonCombo
+	std::map<DreamcastKey, ButtonCombo> reverseButtonMap[NUM_PORTS];
 
 	static std::map<std::string, std::shared_ptr<InputMapping>> loaded_mappings;
 };

--- a/core/input/mapping.h
+++ b/core/input/mapping.h
@@ -169,6 +169,8 @@ public:
 	static constexpr const u32 NUM_PORTS = 4;
 	//! Version 4 adds button combos
 	static constexpr const int CURRENT_FILE_VERSION = 4;
+	//! Initialized and invalid value for code
+	static const u32 INVALID_CODE = InputDef::INVALID_CODE;
 
 	std::string name;
 	float dead_zone = 0.1f;

--- a/core/input/mapping.h
+++ b/core/input/mapping.h
@@ -141,6 +141,12 @@ public:
 		//! @return true iff this ButtonCombo is less than rhs
 		bool operator<(const ButtonCombo& rhs) const;
 
+		//! @return true iff this ButtonCombo is equivalent to rhs
+		bool operator==(const ButtonCombo& rhs) const;
+
+		//! @return true iff this ButtonCombo is not equivalent to rhs
+		bool operator!=(const ButtonCombo& rhs) const;
+
 		//! @return true iff this ButtonCombo is equal to or has an intersection with rhs
 		bool intersects(const ButtonCombo& rhs) const;
 	};

--- a/core/input/mapping.h
+++ b/core/input/mapping.h
@@ -25,6 +25,7 @@
 #include <set>
 #include <memory>
 #include <list>
+#include <vector>
 #include <limits>
 
 namespace emucfg {
@@ -239,6 +240,7 @@ protected:
 
 private:
 	void loadv1(emucfg::ConfigFile& mf);
+	static std::vector<std::string> strSplit(const std::string str, char c, size_t maxsplit = 0);
 
 	std::map<std::pair<u32, bool>, DreamcastKey> axes[NUM_PORTS];
 

--- a/core/input/mapping.h
+++ b/core/input/mapping.h
@@ -178,10 +178,11 @@ public:
 	int rumblePower = 100;
 	int version = CURRENT_FILE_VERSION;
 
-	//! Resolves an ordered set of inputs into keys from multi-input lookup
+	//! Resolves an ordered set of inputs into a key from a multi-input lookup
 	//! @param[in] port The port that the given inputs belong to [0,NUM_PORTS)
 	//! @param[in] inputSet The input set to look for
-	//! @return all keys that should be activated due to the given input set (all combos inputSet ends with)
+	//! @return EMU_BTN_NONE if no key should be activated
+	//! @return the key that should be activated due to the given input set otherwise
 	DreamcastKey get_button_id(u32 port, const InputSet& inputSet) const;
 
 	//! Resolves currently active keys with a released input into keys that should be released
@@ -189,7 +190,7 @@ public:
 	//! @param[in] activeKeys A list of active keys compiled from get_button_id()
 	//! @param[in] releasedInput The released input to check for
 	//! @return all keys that should be released due to the released input
-	DreamcastKey get_button_released_id(
+	std::list<DreamcastKey> get_button_released_ids(
 		u32 port,
 		const std::list<DreamcastKey>& activeKeys,
 		const InputDef& releasedInput) const;

--- a/core/sdl/dreamlink.cpp
+++ b/core/sdl/dreamlink.cpp
@@ -188,7 +188,7 @@ void DreamLinkGamepad::setBaseDefaultMapping(const std::shared_ptr<InputMapping>
 	u32 startCode = mapping->get_button_code(0, DreamcastKey::DC_BTN_START);
 	if (startCode != InputMapping::InputDef::INVALID_CODE)
 	{
-		mapping->set_combo(DreamcastKey::EMU_BTN_MENU, InputMapping::ButtonCombo{
+		mapping->set_button(DreamcastKey::EMU_BTN_MENU, InputMapping::ButtonCombo{
 			InputMapping::InputSet{
 				InputMapping::InputDef{leftTrigger, InputMapping::InputDef::InputType::AXIS_POS},
 				InputMapping::InputDef{rightTrigger, InputMapping::InputDef::InputType::AXIS_POS},

--- a/core/sdl/dreamlink.cpp
+++ b/core/sdl/dreamlink.cpp
@@ -166,27 +166,29 @@ void DreamLinkGamepad::handleEvent(Event event, void *arg)
 void DreamLinkGamepad::resetMappingToDefault(bool arcade, bool gamepad) {
 	SDLGamepad::resetMappingToDefault(arcade, gamepad);
 	if (input_mapper) {
-		setBaseDefaultMapping(input_mapper);
 		if (dreamlink) {
 			dreamlink->setDefaultMapping(input_mapper);
 		}
+		setBaseDefaultMapping(input_mapper);
 	}
 }
 
 std::shared_ptr<InputMapping> DreamLinkGamepad::getDefaultMapping() {
 	std::shared_ptr<InputMapping> mapping = SDLGamepad::getDefaultMapping();
 	if (mapping) {
-		setBaseDefaultMapping(mapping);
 		if (dreamlink) {
 			dreamlink->setDefaultMapping(mapping);
 		}
+		setBaseDefaultMapping(mapping);
 	}
 	return mapping;
 }
 
 void DreamLinkGamepad::setBaseDefaultMapping(const std::shared_ptr<InputMapping>& mapping) const {
-	u32 startCode = mapping->get_button_code(0, DreamcastKey::DC_BTN_START);
-	if (startCode != InputMapping::InputDef::INVALID_CODE)
+	u32 startCode = mapping->get_button_code(maple_port(), DreamcastKey::DC_BTN_START);
+	if (leftTrigger != InputMapping::InputDef::INVALID_CODE &&
+		rightTrigger != InputMapping::InputDef::INVALID_CODE &&
+		startCode != InputMapping::InputDef::INVALID_CODE)
 	{
 		mapping->set_button(DreamcastKey::EMU_BTN_MENU, InputMapping::ButtonCombo{
 			InputMapping::InputSet{

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -129,17 +129,15 @@ public:
 
 	void set_maple_port(int port) override;
 	void registered() override;
-	bool gamepad_btn_input(u32 code, bool pressed) override;
-	bool gamepad_axis_input(u32 code, int value) override;
 	static bool isDreamcastController(int deviceIndex);
 	void resetMappingToDefault(bool arcade, bool gamepad) override;
 
 protected:
 	std::shared_ptr<InputMapping> getDefaultMapping() override;
+	void setBaseDefaultMapping(const std::shared_ptr<InputMapping>& mapping) const;
 
 private:
 	static void handleEvent(Event event, void *arg);
-	void checkKeyCombo();
 
 	std::shared_ptr<DreamLink> dreamlink;
 	bool ltrigPressed = false;

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -324,8 +324,7 @@ void input_sdl_handle()
 				if (event.key.repeat == 0)
 				{
 					auto is_key_mapped = [](u32 code) -> bool {
-						const InputMapping::InputDef inputDef{code, InputMapping::InputDef::InputType::BUTTON};
-						const InputMapping::InputSet inputSet{inputDef};
+						const InputMapping::InputSet inputSet{InputMapping::InputDef::from_button(code)};
 #if defined(_WIN32) && !defined(TARGET_UWP)
 						if (config::UseRawInput)
 						{

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -324,6 +324,8 @@ void input_sdl_handle()
 				if (event.key.repeat == 0)
 				{
 					auto is_key_mapped = [](u32 code) -> bool {
+						const InputMapping::InputDef inputDef{code, InputMapping::InputDef::InputType::BUTTON};
+						const InputMapping::InputSet inputSet{inputDef};
 #if defined(_WIN32) && !defined(TARGET_UWP)
 						if (config::UseRawInput)
 						{
@@ -332,7 +334,7 @@ void input_sdl_handle()
 								auto gamepad = GamepadDevice::GetGamepad(i);
 								if (dynamic_cast<rawinput::RawKeyboard*>(gamepad.get()) != nullptr)
 								{
-									bool mapped = (gamepad->get_input_mapping()->get_button_id(0, code) != EMU_BTN_NONE);
+									bool mapped = !(gamepad->get_input_mapping()->get_button_ids(0, inputSet).empty());
 									if (mapped) return true;
 								}
 							}
@@ -341,7 +343,7 @@ void input_sdl_handle()
 						else
 #endif
 						{
-							return (sdl_keyboard->get_input_mapping()->get_button_id(0, code) != EMU_BTN_NONE);
+							return !(sdl_keyboard->get_input_mapping()->get_button_ids(0, inputSet).empty());
 						}
 					};
 					if (event.type == SDL_KEYDOWN)

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -333,7 +333,7 @@ void input_sdl_handle()
 								auto gamepad = GamepadDevice::GetGamepad(i);
 								if (dynamic_cast<rawinput::RawKeyboard*>(gamepad.get()) != nullptr)
 								{
-									bool mapped = !(gamepad->get_input_mapping()->get_button_ids(0, inputSet).empty());
+									bool mapped = (gamepad->get_input_mapping()->get_button_id(0, inputSet) != EMU_BTN_NONE);
 									if (mapped) return true;
 								}
 							}
@@ -342,7 +342,7 @@ void input_sdl_handle()
 						else
 #endif
 						{
-							return !(sdl_keyboard->get_input_mapping()->get_button_ids(0, inputSet).empty());
+							return (sdl_keyboard->get_input_mapping()->get_button_id(0, inputSet) != EMU_BTN_NONE);
 						}
 					};
 					if (event.type == SDL_KEYDOWN)

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1065,6 +1065,7 @@ static void unmapControl(const std::shared_ptr<InputMapping>& mapping, u32 gamep
 {
 	mapping->clear_button(gamepad_port, key);
 	mapping->clear_axis(gamepad_port, key);
+	mapping->clear_combo(gamepad_port, key);
 }
 
 static DreamcastKey getOppositeDirectionKey(DreamcastKey key)
@@ -1115,6 +1116,15 @@ static DreamcastKey getOppositeDirectionKey(DreamcastKey key)
 		return EMU_BTN_NONE;
 	}
 }
+
+static void displayLabelOrCode(const char *label, u32 code, const char *suffix = "")
+{
+	if (label != nullptr)
+		ImGui::Text("%s%s", label, suffix);
+	else
+		ImGui::Text("[%d]%s", code, suffix);
+}
+
 static void detect_input_popup(const Mapping *mapping)
 {
 	ImVec2 padding = ScaledVec2(20, 20);
@@ -1169,14 +1179,7 @@ static void detect_input_popup(const Mapping *mapping)
 						name = mapped_device->get_axis_name(inputDef.code);
 					}
 
-					if (name != nullptr)
-					{
-						ImGui::Text("%s", name);
-					}
-					else
-					{
-						ImGui::Text("[%d]", inputDef.code);
-					}
+					displayLabelOrCode(name, inputDef.code);
 
 					first = false;
 				}
@@ -1211,14 +1214,6 @@ static void detect_input_popup(const Mapping *mapping)
 	}
 }
 
-static void displayLabelOrCode(const char *label, u32 code, const char *suffix = "")
-{
-	if (label != nullptr)
-		ImGui::Text("%s%s", label, suffix);
-	else
-		ImGui::Text("[%d]%s", code, suffix);
-}
-
 static void displayMappedControl(const std::shared_ptr<GamepadDevice>& gamepad, DreamcastKey key)
 {
 	std::shared_ptr<InputMapping> input_mapping = gamepad->get_input_mapping();
@@ -1240,7 +1235,10 @@ static void displayMappedControl(const std::shared_ptr<GamepadDevice>& gamepad, 
 				name = gamepad->get_axis_name(inputDef.code);
 
 			if (!first)
+			{
 				ImGui::Text(" + ");
+				ImGui::SameLine(0, 0);
+			}
 			displayLabelOrCode(name, inputDef.code);
 			first = false;
 		}

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1054,7 +1054,7 @@ static MapleDeviceType maple_expansion_device_type_from_index(int idx)
 }
 
 static std::shared_ptr<GamepadDevice> mapped_device;
-static std::vector<u32> mapped_codes;  // Now a vector to store multiple buttons
+static std::vector<u32> mapped_codes;  // Now is a vector to store multiple buttons rather then single button inputs.
 static bool analogAxis;
 static bool positiveDirection;
 static u64 map_start_time;
@@ -1160,7 +1160,14 @@ static void detect_input_popup(const Mapping *mapping)
 					if (name != nullptr)
 						ImGui::Text("%s", name);
 					else
-						ImGui::Text("[%d]", code);
+					{
+						// Check if this might be an axis
+						const char* axisName = mapped_device->get_axis_name(code);
+						if (axisName != nullptr)
+							ImGui::Text("%s", axisName);
+						else
+							ImGui::Text("[%d]", code);
+					}
 					
 					first = false;
 				}
@@ -1234,7 +1241,12 @@ static void displayMappedControl(const std::shared_ptr<GamepadDevice>& gamepad, 
 			if (!first)
 				ImGui::SameLine(0, 0);
 			
+			// First try to get button name
 			const char* name = gamepad->get_button_name(code);
+			if (name == nullptr)
+				// If no button name, try to get axis name
+				name = gamepad->get_axis_name(code);
+				
 			if (!first)
 				ImGui::Text(" + ");
 			displayLabelOrCode(name, code);
@@ -1468,7 +1480,7 @@ static void controller_mapping_popup(const std::shared_ptr<GamepadDevice>& gamep
 						if (std::find(mapped_codes.begin(), mapped_codes.end(), code) == mapped_codes.end())
 						{
 							// Limit to a reasonable number of buttons in a combo
-							if (mapped_codes.size() < 2)
+							if (mapped_codes.size() < 8)
 							{
 								mapped_codes.push_back(code);
 								analogAxis = false;

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1459,17 +1459,14 @@ static void controller_mapping_popup(const std::shared_ptr<GamepadDevice>& gamep
 					if (analog)
 					{
 						// For analog inputs - only store a single axis
-						mapped_codes.insert_back(InputMapping::InputDef{
-							code,
-							positive ? InputMapping::InputDef::InputType::AXIS_POS : InputMapping::InputDef::InputType::AXIS_NEG
-						});
+						mapped_codes.insert_back(InputMapping::InputDef::from_axis(code, positive));
 						analogAxis = true;
 						positiveDirection = positive;
 					}
 					else
 					{
 						// For buttons - build a combination
-						mapped_codes.insert_back(InputMapping::InputDef{code, InputMapping::InputDef::InputType::BUTTON});
+						mapped_codes.insert_back(InputMapping::InputDef::from_button(code));
 						analogAxis = false;
 					}
 				});

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1132,8 +1132,14 @@ static void detect_input_popup(const Mapping *mapping)
 		}
 		else
 		{
-			int remaining = (int)(5 - (now - map_start_time) / 1000);
-			ImGui::Text("Time out in %d s", remaining);
+			// Check if device is still detecting input (might have been cancelled by button release)
+			bool still_detecting = mapped_device && mapped_device->is_input_detecting();
+			
+			// If detection was cancelled by button release, close popup immediately
+			int remaining = still_detecting ? (int)(5 - (now - map_start_time) / 1000) : 0;
+			
+			if (still_detecting)
+				ImGui::Text("Time out in %d s", remaining);
 			
 			// Display currently detected buttons during the countdown
 			if (!mapped_codes.empty())

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1136,11 +1136,7 @@ static void detect_input_popup(const Mapping *mapping)
 		u64 now = getTimeMs();
 
 		// Check if we're still in the initial delay period
-		if (now < map_start_time)
-		{
-			ImGui::Text("Starting detection in %d ms...", (int)(map_start_time - now));
-		}
-		else
+		if (now >= map_start_time)
 		{
 			// Check if device is still detecting input (might have been cancelled by button release)
 			bool still_detecting = mapped_device && mapped_device->is_input_detecting();
@@ -1165,7 +1161,7 @@ static void detect_input_popup(const Mapping *mapping)
 					if (!first)
 					{
 						ImGui::SameLine();
-						ImGui::Text("+");
+						ImGui::Text("&");
 						ImGui::SameLine();
 					}
 
@@ -1221,36 +1217,35 @@ static void displayMappedControl(const std::shared_ptr<GamepadDevice>& gamepad, 
 
 	if (!combo.empty())
 	{
-		// Display button combination in "Button1 + Button2 + ..." format
+		// Display button combination in "Button1 & Button2 & ..." format
 		bool first = true;
 		for (const InputMapping::InputDef& inputDef : combo)
 		{
 			if (!first)
-				ImGui::SameLine(0, 0);
-
-			const char* name = nullptr;
-			if (inputDef.is_button())
-				name = gamepad->get_button_name(inputDef.code);
-			else if (inputDef.is_axis())
-				name = gamepad->get_axis_name(inputDef.code);
-
-			if (!first)
 			{
-				ImGui::Text(" + ");
-				ImGui::SameLine(0, 0);
+				ImGui::SameLine();
+				ImGui::Text("&");
+				ImGui::SameLine();
 			}
-			displayLabelOrCode(name, inputDef.code);
+
+			if (inputDef.is_button())
+			{
+				displayLabelOrCode(gamepad->get_button_name(inputDef.code), inputDef.code);
+			}
+			else if (inputDef.is_axis())
+			{
+				displayLabelOrCode(
+					gamepad->get_axis_name(inputDef.code),
+					inputDef.code,
+					(inputDef.type == InputMapping::InputDef::InputType::AXIS_POS ? "+" : "-"));
+			}
+			else
+			{
+				displayLabelOrCode(nullptr, inputDef.code);
+			}
+
 			first = false;
 		}
-		return;
-	}
-
-	std::pair<u32, bool> pair = input_mapping->get_axis_code(gamepad_port, key);
-	u32 code = pair.first;
-	if (code != (u32)-1)
-	{
-		displayLabelOrCode(gamepad->get_axis_name(code), code, pair.second ? "+" : "-");
-		return;
 	}
 }
 

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1065,7 +1065,6 @@ static void unmapControl(const std::shared_ptr<InputMapping>& mapping, u32 gamep
 {
 	mapping->clear_button(gamepad_port, key);
 	mapping->clear_axis(gamepad_port, key);
-	mapping->clear_combo(gamepad_port, key);
 }
 
 static DreamcastKey getOppositeDirectionKey(DreamcastKey key)
@@ -1194,7 +1193,7 @@ static void detect_input_popup(const Mapping *mapping)
 				if (input_mapping != NULL && !mapped_codes.empty())
 				{
 					unmapControl(input_mapping, gamepad_port, mapping->key);
-					input_mapping->set_combo(gamepad_port, mapping->key, InputMapping::ButtonCombo{mapped_codes, true});
+					input_mapping->set_button(gamepad_port, mapping->key, InputMapping::ButtonCombo{mapped_codes, true});
 				}
 
 				// Make sure to cancel input detection to prevent collecting more inputs
@@ -1213,7 +1212,7 @@ static void detect_input_popup(const Mapping *mapping)
 static void displayMappedControl(const std::shared_ptr<GamepadDevice>& gamepad, DreamcastKey key)
 {
 	std::shared_ptr<InputMapping> input_mapping = gamepad->get_input_mapping();
-	InputMapping::ButtonCombo* combo = input_mapping->get_combo_ptr(gamepad_port, key);
+	InputMapping::ButtonCombo* combo = input_mapping->get_button_ptr(gamepad_port, key);
 
 	if (!combo)
 	{

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1218,46 +1218,47 @@ static void displayMappedControl(const std::shared_ptr<GamepadDevice>& gamepad, 
 	{
 		// Try axis
 		std::pair<u32, bool> pair = input_mapping->get_axis_code(gamepad_port, key);
-		u32 code = pair.first;
-		if (code != InputMapping::InputDef::INVALID_CODE)
+		const InputMapping::InputDef inputDef = InputMapping::InputDef::from_axis(pair.first, pair.second);
+		if (inputDef.is_valid())
 		{
-			displayLabelOrCode(gamepad->get_axis_name(code), code, pair.second ? "+" : "-");
+			displayLabelOrCode(gamepad->get_axis_name(inputDef.code), inputDef.code, inputDef.get_suffix());
 		}
-		return;
 	}
-
-	// Display button combination in "Button1 & Button2 & ..." format
-	bool first = true;
-	for (const InputMapping::InputDef& inputDef : combo->inputs)
+	else
 	{
-		if (!first)
+		// Display button combination in "Button1 & Button2 & ..." format
+		bool first = true;
+		for (const InputMapping::InputDef& inputDef : combo->inputs)
 		{
+			if (!first)
+			{
+				ImGui::SameLine();
+				ImGui::Text("&");
+				ImGui::SameLine();
+			}
+
+			const char* name = nullptr;
+			if (inputDef.is_button())
+			{
+				name = gamepad->get_button_name(inputDef.code);
+			}
+			else if (inputDef.is_axis())
+			{
+				name = gamepad->get_axis_name(inputDef.code);
+			}
+
+			displayLabelOrCode(name, inputDef.code, inputDef.get_suffix());
+			first = false;
+		}
+
+		if (combo->inputs.size() > 1)
+		{
+			ImGui::Checkbox("Sequential", &(combo->sequential));
 			ImGui::SameLine();
-			ImGui::Text("&");
-			ImGui::SameLine();
+			ShowHelpMarker(
+				"When checked, this combo will only activate when all keys are pressed in the given sequence.\n"
+				"When not checked, the combo will activate when all keys are pressed in any order.");
 		}
-
-		const char* name = nullptr;
-		if (inputDef.is_button())
-		{
-			name = gamepad->get_button_name(inputDef.code);
-		}
-		else if (inputDef.is_axis())
-		{
-			name = gamepad->get_axis_name(inputDef.code);
-		}
-
-		displayLabelOrCode(name, inputDef.code, inputDef.get_suffix());
-		first = false;
-	}
-
-	if (combo->inputs.size() > 1)
-	{
-		ImGui::Checkbox("Sequential", &(combo->sequential));
-		ImGui::SameLine();
-		ShowHelpMarker(
-			"When checked, this combo will only activate when all keys are pressed in the given sequence.\n"
-			"When not checked, the combo will activate when all keys are pressed in any order.");
 	}
 }
 

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1261,9 +1261,7 @@ static void displayMappedControl(const std::shared_ptr<GamepadDevice>& gamepad, 
 
 		if (combo.inputs.size() > 1)
 		{
-			const bool oldSequential = combo.sequential;
-			ImGui::Checkbox("Sequential", &(combo.sequential));
-			if (oldSequential != combo.sequential)
+			if (ImGui::Checkbox("Sequential", &(combo.sequential)));
 			{
 				// Update mapping with updated combo settings
 				input_mapping->set_button(gamepad_port, key, combo);
@@ -1472,7 +1470,8 @@ static void controller_mapping_popup(const std::shared_ptr<GamepadDevice>& gamep
 				mapped_codes.clear();  // Clear previous button codes
 
 				// Don't detect combos for axes
-				const bool detectCombo = ((systemMapping->key & (DC_AXIS_TRIGGERS | DC_AXIS_STICKS)) == 0);
+				const auto buttonGroup = (systemMapping->key & DC_BTN_GROUP_MASK);
+				const bool detectCombo = (buttonGroup != DC_AXIS_TRIGGERS && buttonGroup != DC_AXIS_STICKS);
 
 				// Setup a callback to collect button/axes presses
 				gamepad->detectInput(true, true, detectCombo, [](u32 code, bool analog, bool positive)

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1261,7 +1261,7 @@ static void displayMappedControl(const std::shared_ptr<GamepadDevice>& gamepad, 
 
 		if (combo.inputs.size() > 1)
 		{
-			if (ImGui::Checkbox("Sequential", &(combo.sequential)));
+			if (ImGui::Checkbox("Sequential", &(combo.sequential)))
 			{
 				// Update mapping with updated combo settings
 				input_mapping->set_button(gamepad_port, key, combo);

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1055,8 +1055,6 @@ static MapleDeviceType maple_expansion_device_type_from_index(int idx)
 
 static std::shared_ptr<GamepadDevice> mapped_device;
 static InputMapping::InputSet mapped_codes;  // Stores multiple buttons in the order they were entered
-static bool analogAxis;
-static bool positiveDirection;
 static u64 map_start_time;
 static bool arcade_button_mode;
 static u32 gamepad_port;
@@ -1193,9 +1191,9 @@ static void detect_input_popup(const Mapping *mapping)
 				if (input_mapping != NULL && !mapped_codes.empty())
 				{
 					unmapControl(input_mapping, gamepad_port, mapping->key);
-					if ((mapping->key & (DC_AXIS_TRIGGERS | DC_AXIS_STICKS)) != 0)
+					if (mapped_codes.size() == 1 && mapped_codes.front().is_axis())
 					{
-						// Single axis to single input mapping
+						// Single axis mapping
 						const InputMapping::InputDef& axisInputDef = mapped_codes.front();
 						const bool positive = (axisInputDef.type == InputMapping::InputDef::InputType::AXIS_POS);
 						input_mapping->set_axis(gamepad_port, mapping->key, axisInputDef.code, positive);
@@ -1483,14 +1481,11 @@ static void controller_mapping_popup(const std::shared_ptr<GamepadDevice>& gamep
 					{
 						// For analog inputs - only store a single axis
 						mapped_codes.insert_back(InputMapping::InputDef::from_axis(code, positive));
-						analogAxis = true;
-						positiveDirection = positive;
 					}
 					else
 					{
 						// For buttons - build a combination
 						mapped_codes.insert_back(InputMapping::InputDef::from_button(code));
-						analogAxis = false;
 					}
 				});
 			}

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1212,9 +1212,9 @@ static void detect_input_popup(const Mapping *mapping)
 static void displayMappedControl(const std::shared_ptr<GamepadDevice>& gamepad, DreamcastKey key)
 {
 	std::shared_ptr<InputMapping> input_mapping = gamepad->get_input_mapping();
-	InputMapping::ButtonCombo* combo = input_mapping->get_button_ptr(gamepad_port, key);
+	InputMapping::ButtonCombo combo = input_mapping->get_button_combo(gamepad_port, key);
 
-	if (!combo || combo->inputs.empty())
+	if (combo.inputs.empty())
 	{
 		// Try axis
 		std::pair<u32, bool> pair = input_mapping->get_axis_code(gamepad_port, key);
@@ -1228,7 +1228,7 @@ static void displayMappedControl(const std::shared_ptr<GamepadDevice>& gamepad, 
 	{
 		// Display button combination in "Button1 & Button2 & ..." format
 		bool first = true;
-		for (const InputMapping::InputDef& inputDef : combo->inputs)
+		for (const InputMapping::InputDef& inputDef : combo.inputs)
 		{
 			if (!first)
 			{
@@ -1251,9 +1251,15 @@ static void displayMappedControl(const std::shared_ptr<GamepadDevice>& gamepad, 
 			first = false;
 		}
 
-		if (combo->inputs.size() > 1)
+		if (combo.inputs.size() > 1)
 		{
-			ImGui::Checkbox("Sequential", &(combo->sequential));
+			const bool oldSequential = combo.sequential;
+			ImGui::Checkbox("Sequential", &(combo.sequential));
+			if (oldSequential != combo.sequential)
+			{
+				// Update mapping with updated combo settings
+				input_mapping->set_button(gamepad_port, key, combo);
+			}
 			ImGui::SameLine();
 			ShowHelpMarker(
 				"When checked, this combo will only activate when all keys are pressed in the given sequence.\n"

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1479,12 +1479,10 @@ static void controller_mapping_popup(const std::shared_ptr<GamepadDevice>& gamep
 				{
 					if (analog)
 					{
-						// For analog inputs - only store a single axis
 						mapped_codes.insert_back(InputMapping::InputDef::from_axis(code, positive));
 					}
 					else
 					{
-						// For buttons - build a combination
 						mapped_codes.insert_back(InputMapping::InputDef::from_button(code));
 					}
 				});

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1469,9 +1469,9 @@ static void controller_mapping_popup(const std::shared_ptr<GamepadDevice>& gamep
 				mapped_device = gamepad;
 				mapped_codes.clear();  // Clear previous button codes
 
-				// Don't detect combos for axes
+				// Detect combos only for EMU_BUTTONS
 				const auto buttonGroup = (systemMapping->key & DC_BTN_GROUP_MASK);
-				const bool detectCombo = (buttonGroup != DC_AXIS_TRIGGERS && buttonGroup != DC_AXIS_STICKS);
+				const bool detectCombo = (buttonGroup == EMU_BUTTONS);
 
 				// Setup a callback to collect button/axes presses
 				gamepad->detectInput(true, true, detectCombo, [](u32 code, bool analog, bool positive)

--- a/tests/inc/test_utils.h
+++ b/tests/inc/test_utils.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#if defined(_WIN32)
+
+#include <thread>
+#include <chrono>
+
+// To ensure usleep() in tests works for Windows
+inline void usleep(unsigned int usec)
+{
+    std::this_thread::sleep_for(std::chrono::microseconds(usec));
+}
+
+#endif

--- a/tests/src/input/ButtonComboTest.cpp
+++ b/tests/src/input/ButtonComboTest.cpp
@@ -1,0 +1,115 @@
+#include "gtest/gtest.h"
+
+#include "input/mapping.h"
+
+class ButtonComboTest : public ::testing::Test
+{
+};
+
+TEST_F(ButtonComboTest, intersects__true__non_sequential_overlap)
+{
+    // Arrange
+    InputMapping::ButtonCombo combo1{
+        InputMapping::InputSet{
+            InputMapping::InputDef::from_button(4993),
+            InputMapping::InputDef::from_axis(409259, false),
+            InputMapping::InputDef::from_axis(898888, true)
+        },
+        false
+    };
+    InputMapping::ButtonCombo combo2{
+        InputMapping::InputSet{
+            InputMapping::InputDef::from_axis(409259, false),
+            InputMapping::InputDef::from_axis(898888, true),
+            InputMapping::InputDef::from_button(4993)
+        },
+        false
+    };
+
+    // Act
+    bool intersects = combo1.intersects(combo2);
+
+    // Assert
+    ASSERT_TRUE(intersects);
+}
+
+TEST_F(ButtonComboTest, intersects__false__sequential)
+{
+    // Arrange
+    InputMapping::ButtonCombo combo1{
+        InputMapping::InputSet{
+            InputMapping::InputDef::from_button(4993),
+            InputMapping::InputDef::from_axis(409259, false),
+            InputMapping::InputDef::from_axis(898888, true)
+        },
+        true
+    };
+    InputMapping::ButtonCombo combo2{
+        InputMapping::InputSet{
+            InputMapping::InputDef::from_axis(409259, false),
+            InputMapping::InputDef::from_axis(898888, true),
+            InputMapping::InputDef::from_button(4993)
+        },
+        true
+    };
+
+    // Act
+    bool intersects = combo1.intersects(combo2);
+
+    // Assert
+    ASSERT_FALSE(intersects);
+}
+
+TEST_F(ButtonComboTest, intersects__false__non_sequential_no_overlap)
+{
+    // Arrange
+    InputMapping::ButtonCombo combo1{
+        InputMapping::InputSet{
+            InputMapping::InputDef::from_button(4993),
+            InputMapping::InputDef::from_axis(409259, false),
+            InputMapping::InputDef::from_axis(898889, true)
+        },
+        false
+    };
+    InputMapping::ButtonCombo combo2{
+        InputMapping::InputSet{
+            InputMapping::InputDef::from_axis(409259, false),
+            InputMapping::InputDef::from_axis(898888, true),
+            InputMapping::InputDef::from_button(4993)
+        },
+        false
+    };
+
+    // Act
+    bool intersects = combo1.intersects(combo2);
+
+    // Assert
+    ASSERT_FALSE(intersects);
+}
+
+TEST_F(ButtonComboTest, intersects__true__sequential)
+{
+    // Arrange
+    InputMapping::ButtonCombo combo1{
+        InputMapping::InputSet{
+            InputMapping::InputDef::from_axis(409259, false),
+            InputMapping::InputDef::from_axis(898888, true),
+            InputMapping::InputDef::from_button(4993)
+        },
+        true
+    };
+    InputMapping::ButtonCombo combo2{
+        InputMapping::InputSet{
+            InputMapping::InputDef::from_axis(409259, false),
+            InputMapping::InputDef::from_axis(898888, true),
+            InputMapping::InputDef::from_button(4993)
+        },
+        true
+    };
+
+    // Act
+    bool intersects = combo1.intersects(combo2);
+
+    // Assert
+    ASSERT_TRUE(intersects);
+}

--- a/tests/src/input/GamepadInputHandlingTest.cpp
+++ b/tests/src/input/GamepadInputHandlingTest.cpp
@@ -12,12 +12,12 @@ public:
         loadMapping();
     }
 
-	void resetMappingToDefault(bool arcade, bool gamepad) override
+    void resetMappingToDefault(bool arcade, bool gamepad) override
     {
         input_mapper = getDefaultMapping();
     }
 
-	std::shared_ptr<InputMapping> getDefaultMapping() override
+    std::shared_ptr<InputMapping> getDefaultMapping() override
     {
         std::shared_ptr<InputMapping> inputMapping = std::make_shared<InputMapping>();
 

--- a/tests/src/input/GamepadInputHandlingTest.cpp
+++ b/tests/src/input/GamepadInputHandlingTest.cpp
@@ -1,0 +1,104 @@
+#include "gtest/gtest.h"
+
+#include "input/gamepad_device.h"
+#include "input/mapping.h"
+
+class TestGamepadDeviceStub : public GamepadDevice
+{
+public:
+    TestGamepadDeviceStub() : GamepadDevice(0, "TestGamepadDeviceStub")
+    {
+        set_maple_port(0);
+        loadMapping();
+    }
+
+	void resetMappingToDefault(bool arcade, bool gamepad) override
+    {
+        input_mapper = getDefaultMapping();
+    }
+
+	std::shared_ptr<InputMapping> getDefaultMapping() override
+    {
+        std::shared_ptr<InputMapping> inputMapping = std::make_shared<InputMapping>();
+
+        const DreamcastKey mappedKey1 = DreamcastKey::DC_BTN_C;
+        const InputMapping::ButtonCombo combo1{
+            InputMapping::InputSet{
+                InputMapping::InputDef{191, InputMapping::InputDef::InputType::AXIS_NEG},
+                InputMapping::InputDef{100, InputMapping::InputDef::InputType::BUTTON},
+                InputMapping::InputDef{3, InputMapping::InputDef::InputType::AXIS_POS}
+            },
+            true
+        };
+        inputMapping->set_button(mappedKey1, combo1);
+        const DreamcastKey mappedKey2 = DreamcastKey::DC_BTN_D;
+        const InputMapping::ButtonCombo combo2{
+            InputMapping::InputSet{
+                InputMapping::InputDef{200, InputMapping::InputDef::InputType::BUTTON},
+                InputMapping::InputDef{789, InputMapping::InputDef::InputType::AXIS_POS},
+                InputMapping::InputDef{3, InputMapping::InputDef::InputType::AXIS_POS}
+            },
+            false
+        };
+        inputMapping->set_button(mappedKey2, combo2);
+        const DreamcastKey mappedKey3 = DreamcastKey::DC_BTN_Z;
+        const InputMapping::ButtonCombo combo3{
+            InputMapping::InputSet{
+                InputMapping::InputDef{3, InputMapping::InputDef::InputType::AXIS_POS},
+                InputMapping::InputDef{100, InputMapping::InputDef::InputType::BUTTON},
+                InputMapping::InputDef{191, InputMapping::InputDef::InputType::AXIS_NEG}
+            },
+            true
+        };
+        inputMapping->set_button(mappedKey3, combo3);
+        inputMapping->set_button(DreamcastKey::DC_BTN_A, 100);
+        inputMapping->set_button(DreamcastKey::DC_BTN_B, 200);
+        inputMapping->set_axis(DreamcastKey::DC_AXIS_LT, 1, true);
+        inputMapping->set_axis(DreamcastKey::DC_AXIS_RT, 2, true);
+        inputMapping->set_axis(DreamcastKey::DC_AXIS_UP, 3, true);
+        inputMapping->set_axis(DreamcastKey::DC_AXIS_DOWN, 3, false);
+        inputMapping->name = "save test case";
+        inputMapping->dead_zone = 0.33;
+        inputMapping->rumblePower = 98;
+        inputMapping->saturation = 0.50;
+
+        return inputMapping;
+    }
+};
+
+class GamepadeInputHandlingTest : public ::testing::Test
+{
+protected:
+    TestGamepadDeviceStub gamepadDevice;
+};
+
+TEST_F(GamepadeInputHandlingTest, combo_test)
+{
+    gamepadDevice.gamepad_btn_input(100, true);
+    u32 currentCode = ~0;
+    currentCode &= ~static_cast<u32>(DreamcastKey::DC_BTN_A);
+    ASSERT_TRUE(kcode[0], currentCode);
+    gamepadDevice.gamepad_axis_input(3, 30000);
+    ASSERT_TRUE(kcode[0], currentCode);
+    gamepadDevice.gamepad_axis_input(191, -30000);
+    ASSERT_TRUE(kcode[0], currentCode); // combo 1 and 3 should not be active - wrong order
+    gamepadDevice.gamepad_axis_input(191, 0);
+    ASSERT_TRUE(kcode[0], currentCode);
+    gamepadDevice.gamepad_btn_input(100, false);
+    currentCode |= static_cast<u32>(DreamcastKey::DC_BTN_A);
+    ASSERT_TRUE(kcode[0], currentCode);
+    gamepadDevice.gamepad_btn_input(100, true);
+    currentCode &= ~static_cast<u32>(DreamcastKey::DC_BTN_A);
+    ASSERT_TRUE(kcode[0], currentCode);
+    gamepadDevice.gamepad_axis_input(191, -30000); // combo 3 should now be active
+    currentCode &= ~static_cast<u32>(DreamcastKey::DC_BTN_Z);
+    ASSERT_TRUE(kcode[0], currentCode);
+    gamepadDevice.gamepad_axis_input(789, 30000);
+    ASSERT_TRUE(kcode[0], currentCode);
+    gamepadDevice.gamepad_btn_input(100, true); // combo 2 will take precedence over B
+    currentCode &= ~static_cast<u32>(DreamcastKey::DC_BTN_D);
+    ASSERT_TRUE(kcode[0], currentCode);
+    gamepadDevice.gamepad_axis_input(789, 0);
+    currentCode |= static_cast<u32>(DreamcastKey::DC_BTN_D);
+    ASSERT_TRUE(kcode[0], currentCode);
+}

--- a/tests/src/input/GamepadInputHandlingTest.cpp
+++ b/tests/src/input/GamepadInputHandlingTest.cpp
@@ -101,4 +101,7 @@ TEST_F(GamepadeInputHandlingTest, combo_test)
     gamepadDevice.gamepad_axis_input(789, 0);
     currentCode |= static_cast<u32>(DreamcastKey::DC_BTN_D);
     ASSERT_TRUE(kcode[0], currentCode);
+    gamepadDevice.gamepad_btn_input(100, true); // This activates B now
+    currentCode &= ~static_cast<u32>(DreamcastKey::DC_BTN_B);
+    ASSERT_TRUE(kcode[0], currentCode);
 }

--- a/tests/src/input/InputDefTest.cpp
+++ b/tests/src/input/InputDefTest.cpp
@@ -1,0 +1,227 @@
+#include "gtest/gtest.h"
+
+#include <list>
+#include <set>
+
+#include "input/mapping.h"
+
+class InputDefTest : public ::testing::Test
+{
+};
+
+TEST_F(InputDefTest, hash)
+{
+    // Arrange/Act
+    const std::list<u64> hashes = {
+        InputMapping::InputDef{0, InputMapping::InputDef::InputType::BUTTON}.get_hash(),
+        InputMapping::InputDef{0, InputMapping::InputDef::InputType::AXIS_POS}.get_hash(),
+        InputMapping::InputDef{0, InputMapping::InputDef::InputType::AXIS_NEG}.get_hash(),
+        InputMapping::InputDef{1, InputMapping::InputDef::InputType::BUTTON}.get_hash(),
+        InputMapping::InputDef{2, InputMapping::InputDef::InputType::AXIS_POS}.get_hash(),
+        InputMapping::InputDef{3, InputMapping::InputDef::InputType::AXIS_NEG}.get_hash()
+    };
+
+    // Assert
+    // Ensure all hash values are distinct
+    std::set<u64> hashSet;
+    for (const u64& hash : hashes)
+    {
+        hashSet.insert(hash);
+    }
+    EXPECT_EQ(hashes.size(), hashSet.size());
+}
+
+TEST_F(InputDefTest, is_button)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef1{0, InputMapping::InputDef::InputType::BUTTON};
+    const InputMapping::InputDef inputDef2{0, InputMapping::InputDef::InputType::AXIS_POS};
+    const InputMapping::InputDef inputDef3{0, InputMapping::InputDef::InputType::AXIS_NEG};
+
+    // Act/Assert
+    EXPECT_TRUE(inputDef1.is_button());
+    EXPECT_FALSE(inputDef2.is_button());
+    EXPECT_FALSE(inputDef3.is_button());
+}
+
+TEST_F(InputDefTest, is_axis)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef1{0, InputMapping::InputDef::InputType::BUTTON};
+    const InputMapping::InputDef inputDef2{0, InputMapping::InputDef::InputType::AXIS_POS};
+    const InputMapping::InputDef inputDef3{0, InputMapping::InputDef::InputType::AXIS_NEG};
+
+    // Act/Assert
+    EXPECT_FALSE(inputDef1.is_axis());
+    EXPECT_TRUE(inputDef2.is_axis());
+    EXPECT_TRUE(inputDef3.is_axis());
+}
+
+TEST_F(InputDefTest, is_valid__true)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef1{0, InputMapping::InputDef::InputType::BUTTON};
+    const InputMapping::InputDef inputDef2{0, InputMapping::InputDef::InputType::AXIS_POS};
+    const InputMapping::InputDef inputDef3{0, InputMapping::InputDef::InputType::AXIS_NEG};
+
+    // Act/Assert
+    EXPECT_TRUE(inputDef1.is_valid());
+    EXPECT_TRUE(inputDef2.is_valid());
+    EXPECT_TRUE(inputDef3.is_valid());
+}
+
+TEST_F(InputDefTest, is_valid__false__invalid_code)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef{InputMapping::INVALID_CODE, InputMapping::InputDef::InputType::BUTTON};
+
+    // Act/Assert
+    EXPECT_FALSE(inputDef.is_valid());
+}
+
+TEST_F(InputDefTest, is_valid__false__invalid_type)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef{0, static_cast<InputMapping::InputDef::InputType>(1000)};
+
+    // Act/Assert
+    EXPECT_FALSE(inputDef.is_valid());
+}
+
+TEST_F(InputDefTest, get_suffix_axis_pos_type)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef{0, InputMapping::InputDef::InputType::AXIS_POS};
+
+    // Act
+    const char* suffix = inputDef.get_suffix();
+
+    // Assert
+    EXPECT_STREQ(suffix, "+");
+}
+
+TEST_F(InputDefTest, get_suffix_axis_neg_type)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef{0, InputMapping::InputDef::InputType::AXIS_NEG};
+
+    // Act
+    const char* suffix = inputDef.get_suffix();
+
+    // Assert
+    EXPECT_STREQ(suffix, "-");
+}
+
+TEST_F(InputDefTest, get_suffix_button_type)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef{0, InputMapping::InputDef::InputType::BUTTON};
+
+    // Act
+    const char* suffix = inputDef.get_suffix();
+
+    // Assert
+    EXPECT_STREQ(suffix, "");
+}
+
+TEST_F(InputDefTest, to_str_axis_pos_type)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef{112233, InputMapping::InputDef::InputType::AXIS_POS};
+
+    // Act
+    std::string str = inputDef.to_str();
+
+    // Assert
+    EXPECT_EQ(str, "112233+");
+}
+
+TEST_F(InputDefTest, to_str_axis_neg_type)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef{112233, InputMapping::InputDef::InputType::AXIS_NEG};
+
+    // Act
+    std::string str = inputDef.to_str();
+
+    // Assert
+    EXPECT_EQ(str, "112233-");
+}
+
+TEST_F(InputDefTest, to_str_button_type)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef{112233, InputMapping::InputDef::InputType::BUTTON};
+
+    // Act
+    std::string str = inputDef.to_str();
+
+    // Assert
+    EXPECT_EQ(str, "112233");
+}
+
+TEST_F(InputDefTest, from_str_axis_pos_type)
+{
+    // Arrange
+    const std::string str = "112233+";
+
+    // Act
+    const InputMapping::InputDef inputDef = InputMapping::InputDef::from_str(str);
+
+    // Assert
+    EXPECT_EQ(inputDef, (InputMapping::InputDef{112233, InputMapping::InputDef::InputType::AXIS_POS}));
+}
+
+TEST_F(InputDefTest, from_str_axis_neg_type)
+{
+    // Arrange
+    const std::string str = "112233-";
+
+    // Act
+    const InputMapping::InputDef inputDef = InputMapping::InputDef::from_str(str);
+
+    // Assert
+    EXPECT_EQ(inputDef, (InputMapping::InputDef{112233, InputMapping::InputDef::InputType::AXIS_NEG}));
+}
+
+TEST_F(InputDefTest, from_str_button_type)
+{
+    // Arrange
+    const std::string str = "112233";
+
+    // Act
+    const InputMapping::InputDef inputDef = InputMapping::InputDef::from_str(str);
+
+    // Assert
+    EXPECT_EQ(inputDef, (InputMapping::InputDef{112233, InputMapping::InputDef::InputType::BUTTON}));
+}
+
+TEST_F(InputDefTest, from_button)
+{
+    // Act
+    const InputMapping::InputDef inputDef = InputMapping::InputDef::from_button(456);
+
+    // Assert
+    EXPECT_EQ(inputDef.code, 456);
+    EXPECT_EQ(inputDef.type, InputMapping::InputDef::InputType::BUTTON);
+}
+
+TEST_F(InputDefTest, from_axis_pos)
+{
+    // Act
+    const InputMapping::InputDef inputDef = InputMapping::InputDef::from_axis(456, true);
+
+    // Assert
+    EXPECT_EQ(inputDef.code, 456);
+    EXPECT_EQ(inputDef.type, InputMapping::InputDef::InputType::AXIS_POS);
+}
+
+TEST_F(InputDefTest, from_axis_neg)
+{
+    // Act
+    const InputMapping::InputDef inputDef = InputMapping::InputDef::from_axis(456, false);
+
+    // Assert
+    EXPECT_EQ(inputDef.code, 456);
+    EXPECT_EQ(inputDef.type, InputMapping::InputDef::InputType::AXIS_NEG);
+}

--- a/tests/src/input/InputMappingConfigFileTest.cpp
+++ b/tests/src/input/InputMappingConfigFileTest.cpp
@@ -1,0 +1,190 @@
+#include "gtest/gtest.h"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+#include "input/mapping.h"
+
+class InputMappingConfigFileTest : public ::testing::Test
+{
+protected:
+    static constexpr const char* CONFIG_FILE_NAME = "InputMappingConfigFileTest";
+    static constexpr const char* CONFIG_SAVE_DIR = "mappings";
+
+    std::filesystem::path getConfigFilepath()
+    {
+        return std::filesystem::path(CONFIG_SAVE_DIR) / CONFIG_FILE_NAME;
+    }
+
+    void removeConfigFile()
+    {
+        std::filesystem::remove(getConfigFilepath());
+    }
+
+    void writeConfigFile(const std::string& contents)
+    {
+        std::ofstream configFile(getConfigFilepath());
+        configFile << contents;
+        configFile.close();
+    }
+
+    void SetUp() override
+    {
+        removeConfigFile();
+    }
+
+    void TearDown() override
+    {
+        removeConfigFile();
+    }
+};
+
+TEST_F(InputMappingConfigFileTest, save)
+{
+    // Arrange
+    InputMapping inputMapping;
+    const DreamcastKey mappedKey1 = DreamcastKey::EMU_BTN_MENU;
+    const InputMapping::ButtonCombo combo1{
+        InputMapping::InputSet{
+            InputMapping::InputDef{191, InputMapping::InputDef::InputType::AXIS_NEG},
+            InputMapping::InputDef{123, InputMapping::InputDef::InputType::BUTTON},
+            InputMapping::InputDef{987, InputMapping::InputDef::InputType::AXIS_POS}
+        },
+        true
+    };
+    inputMapping.set_button(mappedKey1, combo1);
+    const DreamcastKey mappedKey2 = DreamcastKey::EMU_BTN_SAVESTATE;
+    const InputMapping::ButtonCombo combo2{
+        InputMapping::InputSet{
+            InputMapping::InputDef{321, InputMapping::InputDef::InputType::BUTTON},
+            InputMapping::InputDef{789, InputMapping::InputDef::InputType::AXIS_POS},
+            InputMapping::InputDef{1, InputMapping::InputDef::InputType::AXIS_NEG}
+        },
+        false
+    };
+    inputMapping.set_button(mappedKey2, combo2);
+    const DreamcastKey mappedKey3 = DreamcastKey::EMU_BTN_LOADSTATE;
+    const InputMapping::ButtonCombo combo3{
+        InputMapping::InputSet{
+            InputMapping::InputDef{987, InputMapping::InputDef::InputType::AXIS_POS},
+            InputMapping::InputDef{123, InputMapping::InputDef::InputType::BUTTON},
+            InputMapping::InputDef{191, InputMapping::InputDef::InputType::AXIS_NEG}
+        },
+        true
+    };
+    inputMapping.set_button(mappedKey3, combo3);
+    inputMapping.set_button(DreamcastKey::DC_BTN_A, 100);
+    inputMapping.set_button(DreamcastKey::DC_BTN_B, 200);
+    inputMapping.set_axis(DreamcastKey::DC_AXIS_LT, 1, true);
+    inputMapping.set_axis(DreamcastKey::DC_AXIS_RT, 2, true);
+    inputMapping.set_axis(DreamcastKey::DC_AXIS_UP, 3, true);
+    inputMapping.set_axis(DreamcastKey::DC_AXIS_DOWN, 3, false);
+    inputMapping.name = "save test case";
+    inputMapping.dead_zone = 0.33;
+    inputMapping.rumblePower = 98;
+    inputMapping.saturation = 0.50;
+
+    // Act
+    inputMapping.save(CONFIG_FILE_NAME);
+
+    // Assert
+    std::ifstream configFile(getConfigFilepath());
+    std::stringstream buffer;
+    buffer << configFile.rdbuf();
+    ASSERT_EQ(buffer.str(), R"([analog]
+bind0 = 1+:btn_trigger_left
+bind1 = 2+:btn_trigger_right
+bind2 = 3-:btn_analog_down
+bind3 = 3+:btn_analog_up
+
+[combo]
+bind0 = 321,789+,1-:btn_quick_save:0
+bind1 = 987+,123,191-:btn_jump_state:1
+bind2 = 191-,123,987+:btn_menu:1
+
+[digital]
+bind0 = 100:btn_a
+bind1 = 200:btn_b
+
+[emulator]
+dead_zone = 33
+mapping_name = save test case
+rumble_power = 98
+saturation = 50
+version = 4
+
+)");
+}
+
+TEST_F(InputMappingConfigFileTest, load)
+{
+    // Arrange
+    const std::string fileData = R"([analog]
+bind0 = 1+:btn_trigger_left
+bind1 = 2+:btn_trigger_right
+bind2 = 3-:btn_analog_down
+bind3 = 3+:btn_analog_up
+
+[combo]
+bind0 = 321,789+,1-:btn_quick_save:0
+bind1 = 987+,123,191-:btn_jump_state:1
+bind2 = 191-,123,987+:btn_menu:1
+
+[digital]
+bind0 = 100:btn_a
+bind1 = 200:btn_b
+
+[emulator]
+dead_zone = 33
+mapping_name = save test case
+rumble_power = 98
+saturation = 50
+version = 4)";
+    writeConfigFile(fileData);
+
+    // Act
+    std::shared_ptr<InputMapping> inputMapping = InputMapping::LoadMapping(CONFIG_FILE_NAME);
+
+    // Assert
+    const DreamcastKey mappedKey1 = DreamcastKey::EMU_BTN_MENU;
+    const InputMapping::ButtonCombo combo1{
+        InputMapping::InputSet{
+            InputMapping::InputDef{191, InputMapping::InputDef::InputType::AXIS_NEG},
+            InputMapping::InputDef{123, InputMapping::InputDef::InputType::BUTTON},
+            InputMapping::InputDef{987, InputMapping::InputDef::InputType::AXIS_POS}
+        },
+        true
+    };
+    EXPECT_EQ(inputMapping->get_button_combo(0, mappedKey1), combo1);
+    const DreamcastKey mappedKey2 = DreamcastKey::EMU_BTN_SAVESTATE;
+    const InputMapping::ButtonCombo combo2{
+        InputMapping::InputSet{
+            InputMapping::InputDef{321, InputMapping::InputDef::InputType::BUTTON},
+            InputMapping::InputDef{789, InputMapping::InputDef::InputType::AXIS_POS},
+            InputMapping::InputDef{1, InputMapping::InputDef::InputType::AXIS_NEG}
+        },
+        false
+    };
+    EXPECT_EQ(inputMapping->get_button_combo(0, mappedKey2), combo2);
+    const DreamcastKey mappedKey3 = DreamcastKey::EMU_BTN_LOADSTATE;
+    const InputMapping::ButtonCombo combo3{
+        InputMapping::InputSet{
+            InputMapping::InputDef{987, InputMapping::InputDef::InputType::AXIS_POS},
+            InputMapping::InputDef{123, InputMapping::InputDef::InputType::BUTTON},
+            InputMapping::InputDef{191, InputMapping::InputDef::InputType::AXIS_NEG}
+        },
+        true
+    };
+    EXPECT_EQ(inputMapping->get_button_combo(0, mappedKey3), combo3);
+    EXPECT_EQ(inputMapping->get_button_code(0, DreamcastKey::DC_BTN_A), 100);
+    EXPECT_EQ(inputMapping->get_button_code(0, DreamcastKey::DC_BTN_B), 200);
+    EXPECT_EQ(inputMapping->get_axis_code(0, DreamcastKey::DC_AXIS_LT), (std::pair<u32,bool>(1, true)));
+    EXPECT_EQ(inputMapping->get_axis_code(0, DreamcastKey::DC_AXIS_RT), (std::pair<u32,bool>(2, true)));
+    EXPECT_EQ(inputMapping->get_axis_code(0, DreamcastKey::DC_AXIS_UP), (std::pair<u32,bool>(3, true)));
+    EXPECT_EQ(inputMapping->get_axis_code(0, DreamcastKey::DC_AXIS_DOWN), (std::pair<u32,bool>(3, false)));
+    EXPECT_EQ(inputMapping->name, "save test case");
+    EXPECT_NEAR(inputMapping->dead_zone, 0.33, 1e-3);
+    EXPECT_EQ(inputMapping->rumblePower, 98);
+    EXPECT_NEAR(inputMapping->saturation, 0.50, 1e-3);
+}

--- a/tests/src/input/InputSetTest.cpp
+++ b/tests/src/input/InputSetTest.cpp
@@ -1,0 +1,188 @@
+#include "gtest/gtest.h"
+
+#include "input/mapping.h"
+
+class InputSetTest : public ::testing::Test
+{
+};
+
+TEST_F(InputSetTest, default_constructor)
+{
+    // Arrange/Act
+    const InputMapping::InputSet defaultValues;
+
+    // Assert
+    EXPECT_TRUE(defaultValues.empty());
+}
+
+TEST_F(InputSetTest, initializer_constructor_all_unique)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef1{0, InputMapping::InputDef::InputType::BUTTON};
+    const InputMapping::InputDef inputDef2{0, InputMapping::InputDef::InputType::AXIS_POS};
+    const InputMapping::InputDef inputDef3{1, InputMapping::InputDef::InputType::AXIS_NEG};
+    const InputMapping::InputDef inputDef4{1, InputMapping::InputDef::InputType::BUTTON};
+    const InputMapping::InputDef inputDef5{2, InputMapping::InputDef::InputType::AXIS_POS};
+    const InputMapping::InputDef inputDef6{3, InputMapping::InputDef::InputType::AXIS_NEG};
+
+    // Act
+    const InputMapping::InputSet inputSet{
+        inputDef1, inputDef2, inputDef3, inputDef4, inputDef5, inputDef6
+    };
+
+    // Assert
+    ASSERT_EQ(inputSet.size(), 6);
+    InputMapping::InputSet::const_iterator iter = inputSet.cbegin();
+    EXPECT_EQ(*iter++, inputDef1);
+    EXPECT_EQ(*iter++, inputDef2);
+    EXPECT_EQ(*iter++, inputDef3);
+    EXPECT_EQ(*iter++, inputDef4);
+    EXPECT_EQ(*iter++, inputDef5);
+    EXPECT_EQ(*iter++, inputDef6);
+}
+
+TEST_F(InputSetTest, initializer_constructor_duplicate_pos_neg)
+{
+    // Arrange
+    // Can't contain both positive and negative of the same code - wouldn't be physically possible
+    const InputMapping::InputDef inputDef1{0, InputMapping::InputDef::InputType::AXIS_POS};
+    const InputMapping::InputDef inputDef2{0, InputMapping::InputDef::InputType::AXIS_NEG};
+
+    // Act
+    const InputMapping::InputSet inputSet{
+        inputDef1, inputDef2
+    };
+
+    // Assert
+    ASSERT_EQ(inputSet.size(), 1);
+    InputMapping::InputSet::const_iterator iter = inputSet.cbegin();
+    EXPECT_EQ(*iter++, inputDef2); // Most recent (last) insertion takes precedence
+}
+
+TEST_F(InputSetTest, initializer_constructor_duplicates)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef1{0, InputMapping::InputDef::InputType::BUTTON};
+    const InputMapping::InputDef inputDef2{0, InputMapping::InputDef::InputType::AXIS_POS};
+    const InputMapping::InputDef inputDef3{1, InputMapping::InputDef::InputType::AXIS_NEG};
+    const InputMapping::InputDef inputDef4{0, InputMapping::InputDef::InputType::BUTTON};
+    const InputMapping::InputDef inputDef5{0, InputMapping::InputDef::InputType::AXIS_POS};
+    const InputMapping::InputDef inputDef6{1, InputMapping::InputDef::InputType::AXIS_NEG};
+
+    // Act
+    const InputMapping::InputSet inputSet{
+        inputDef1, inputDef2, inputDef3, inputDef4, inputDef5, inputDef6
+    };
+
+    // Assert
+    ASSERT_EQ(inputSet.size(), 3);
+    InputMapping::InputSet::const_iterator iter = inputSet.cbegin();
+    EXPECT_EQ(*iter++, inputDef1);
+    EXPECT_EQ(*iter++, inputDef2);
+    EXPECT_EQ(*iter++, inputDef3);
+}
+
+TEST_F(InputSetTest, contains)
+{
+    // Arrange
+    const InputMapping::InputDef inputDef1{123, InputMapping::InputDef::InputType::BUTTON};
+    const InputMapping::InputDef inputDef2{456, InputMapping::InputDef::InputType::AXIS_POS};
+    const InputMapping::InputDef inputDef3{789, InputMapping::InputDef::InputType::AXIS_NEG};
+    const InputMapping::InputDef inputDef4{937547, InputMapping::InputDef::InputType::BUTTON};
+    const InputMapping::InputDef inputDef5{8675309, InputMapping::InputDef::InputType::AXIS_POS};
+    const InputMapping::InputDef inputDef6{424242424, InputMapping::InputDef::InputType::AXIS_NEG};
+    const InputMapping::InputSet inputSet{
+        inputDef1, inputDef2, inputDef3, inputDef4, inputDef5, inputDef6
+    };
+
+    // Act/Assert
+    EXPECT_TRUE(inputSet.contains(inputDef3));
+    EXPECT_FALSE(inputSet.contains(InputMapping::InputDef{8675309, InputMapping::InputDef::InputType::BUTTON}));
+}
+
+TEST_F(InputSetTest, ends_with_sequential__true)
+{
+    // Arrange
+    const InputMapping::InputSet inputSet1{
+        InputMapping::InputDef::from_button(1),
+        InputMapping::InputDef::from_button(2),
+        InputMapping::InputDef::from_axis(1, true),
+        InputMapping::InputDef::from_axis(100, false)
+    };
+    const InputMapping::InputSet inputSet2{
+        InputMapping::InputDef::from_button(2),
+        InputMapping::InputDef::from_axis(1, true),
+        InputMapping::InputDef::from_axis(100, false)
+    };
+
+    // Act
+    bool result = inputSet1.ends_with(inputSet2, true);
+
+    // Assert
+    ASSERT_TRUE(result);
+}
+
+TEST_F(InputSetTest, ends_with_sequential__false)
+{
+    // Arrange
+    const InputMapping::InputSet inputSet1{
+        InputMapping::InputDef::from_button(1),
+        InputMapping::InputDef::from_button(2),
+        InputMapping::InputDef::from_axis(1, true),
+        InputMapping::InputDef::from_axis(100, false)
+    };
+    const InputMapping::InputSet inputSet2{
+        InputMapping::InputDef::from_button(2),
+        InputMapping::InputDef::from_axis(100, false),
+        InputMapping::InputDef::from_axis(1, true)
+    };
+
+    // Act
+    bool result = inputSet1.ends_with(inputSet2, true);
+
+    // Assert
+    ASSERT_FALSE(result);
+}
+
+TEST_F(InputSetTest, ends_with_nonsequential__true)
+{
+    // Arrange
+    const InputMapping::InputSet inputSet1{
+        InputMapping::InputDef::from_button(1),
+        InputMapping::InputDef::from_button(2),
+        InputMapping::InputDef::from_axis(1, true),
+        InputMapping::InputDef::from_axis(100, false)
+    };
+    const InputMapping::InputSet inputSet2{
+        InputMapping::InputDef::from_button(2),
+        InputMapping::InputDef::from_axis(100, false),
+        InputMapping::InputDef::from_axis(1, true)
+    };
+
+    // Act
+    bool result = inputSet1.ends_with(inputSet2, false);
+
+    // Assert
+    ASSERT_TRUE(result);
+}
+
+TEST_F(InputSetTest, ends_with_nonsequential__false)
+{
+    // Arrange
+    const InputMapping::InputSet inputSet1{
+        InputMapping::InputDef::from_button(1),
+        InputMapping::InputDef::from_button(2),
+        InputMapping::InputDef::from_axis(1, true),
+        InputMapping::InputDef::from_axis(100, false)
+    };
+    const InputMapping::InputSet inputSet2{
+        InputMapping::InputDef::from_button(2),
+        InputMapping::InputDef::from_axis(100, false)
+    };
+
+    // Act
+    bool result = inputSet1.ends_with(inputSet2, false);
+
+    // Assert
+    ASSERT_FALSE(result);
+}

--- a/tests/src/input/MultiBindMappingTest.cpp
+++ b/tests/src/input/MultiBindMappingTest.cpp
@@ -34,8 +34,8 @@ TEST_F(MultiBindMappingTest, get_button_code__not_found)
     const u32 retrievedCode = inputMapping.get_button_code(0, DreamcastKey::DC_BTN_B);
 
     // Assert
-    const u32 expected = InputMapping::InputDef::INVALID_CODE;
-    ASSERT_EQ(retrievedCode, expected);
+    const u32 expectedCode = InputMapping::InputDef::INVALID_CODE;
+    ASSERT_EQ(retrievedCode, expectedCode);
 }
 
 TEST_F(MultiBindMappingTest, get_button_combo__found)

--- a/tests/src/input/MultiBindMappingTest.cpp
+++ b/tests/src/input/MultiBindMappingTest.cpp
@@ -34,7 +34,8 @@ TEST_F(MultiBindMappingTest, get_button_code__not_found)
     const u32 retrievedCode = inputMapping.get_button_code(0, DreamcastKey::DC_BTN_B);
 
     // Assert
-    ASSERT_EQ(retrievedCode, InputMapping::INVALID_CODE);
+    const u32 expected = InputMapping::InputDef::INVALID_CODE;
+    ASSERT_EQ(retrievedCode, expected);
 }
 
 TEST_F(MultiBindMappingTest, get_button_combo__found)

--- a/tests/src/input/MultiBindMappingTest.cpp
+++ b/tests/src/input/MultiBindMappingTest.cpp
@@ -1,0 +1,149 @@
+#include "gtest/gtest.h"
+
+#include "input/mapping.h"
+
+class MultiBindMappingTest : public ::testing::Test
+{
+protected:
+    InputMapping inputMapping;
+
+    void SetUp() override
+    {}
+};
+
+TEST_F(MultiBindMappingTest, get_button_code__found)
+{
+    // Arrange
+    const DreamcastKey mappedKey = DreamcastKey::DC_BTN_A;
+    const u32 mappedCode = 4294967294;
+    inputMapping.set_button(mappedKey, mappedCode);
+
+    // Act
+    const u32 retrievedCode = inputMapping.get_button_code(0, mappedKey);
+
+    // Assert
+    ASSERT_EQ(retrievedCode, mappedCode);
+}
+
+TEST_F(MultiBindMappingTest, get_button_code__not_found)
+{
+    // Arrange
+    inputMapping.set_button(DreamcastKey::DC_BTN_A, 4294967294);
+
+    // Act
+    const u32 retrievedCode = inputMapping.get_button_code(0, DreamcastKey::DC_BTN_B);
+
+    // Assert
+    ASSERT_EQ(retrievedCode, InputMapping::INVALID_CODE);
+}
+
+TEST_F(MultiBindMappingTest, get_button_combo__found)
+{
+    // Arrange
+    const DreamcastKey mappedKey = DreamcastKey::DC_BTN_A;
+    const InputMapping::ButtonCombo combo{
+        InputMapping::InputSet{
+            InputMapping::InputDef{123, InputMapping::InputDef::InputType::BUTTON},
+            InputMapping::InputDef{987, InputMapping::InputDef::InputType::AXIS_POS},
+            InputMapping::InputDef{191, InputMapping::InputDef::InputType::AXIS_NEG}
+        },
+        true
+    };
+    inputMapping.set_button(mappedKey, combo);
+
+    // Act
+    const InputMapping::ButtonCombo retrievedCombo = inputMapping.get_button_combo(0, mappedKey);
+
+    // Assert
+    ASSERT_EQ(retrievedCombo, combo);
+}
+
+TEST_F(MultiBindMappingTest, get_button_combo__not_found)
+{
+    // Arrange
+    inputMapping.set_button(DreamcastKey::DC_BTN_A, 4294967294);
+
+    // Act
+    const InputMapping::ButtonCombo retrievedCombo = inputMapping.get_button_combo(0, DreamcastKey::DC_BTN_B);
+
+    // Assert
+    EXPECT_EQ(retrievedCombo, InputMapping::ButtonCombo());
+    EXPECT_TRUE(retrievedCombo.inputs.empty());
+}
+
+TEST_F(MultiBindMappingTest, get_button_combo__not_found__overlapping_element)
+{
+    // Arrange
+    const DreamcastKey mappedKey1 = DreamcastKey::DC_BTN_A;
+    const InputMapping::ButtonCombo combo1{
+        InputMapping::InputSet{
+            InputMapping::InputDef{191, InputMapping::InputDef::InputType::AXIS_NEG},
+            InputMapping::InputDef{123, InputMapping::InputDef::InputType::BUTTON},
+            InputMapping::InputDef{987, InputMapping::InputDef::InputType::AXIS_POS}
+        },
+        true
+    };
+    inputMapping.set_button(mappedKey1, combo1);
+    const DreamcastKey mappedKey2 = DreamcastKey::DC_BTN_B;
+    // Contains all of the same keys and is not sequential, so the above should be removed when this is added
+    const InputMapping::ButtonCombo combo2{
+        InputMapping::InputSet{
+            InputMapping::InputDef{123, InputMapping::InputDef::InputType::BUTTON},
+            InputMapping::InputDef{987, InputMapping::InputDef::InputType::AXIS_POS},
+            InputMapping::InputDef{191, InputMapping::InputDef::InputType::AXIS_NEG}
+        },
+        false
+    };
+    inputMapping.set_button(mappedKey2, combo2);
+
+    // Act
+    const InputMapping::ButtonCombo retrievedCombo = inputMapping.get_button_combo(0, mappedKey1);
+
+    // Assert
+    EXPECT_EQ(retrievedCombo, InputMapping::ButtonCombo());
+}
+
+TEST_F(MultiBindMappingTest, get_button_combo__found__sequential_not_overlapped)
+{
+    // Arrange
+    const DreamcastKey mappedKey1 = DreamcastKey::DC_BTN_A;
+    const InputMapping::ButtonCombo combo1{
+        InputMapping::InputSet{
+            InputMapping::InputDef{191, InputMapping::InputDef::InputType::AXIS_NEG},
+            InputMapping::InputDef{123, InputMapping::InputDef::InputType::BUTTON},
+            InputMapping::InputDef{987, InputMapping::InputDef::InputType::AXIS_POS}
+        },
+        true
+    };
+    inputMapping.set_button(mappedKey1, combo1);
+    const DreamcastKey mappedKey2 = DreamcastKey::DC_BTN_B;
+    const InputMapping::ButtonCombo combo2{
+        InputMapping::InputSet{
+            InputMapping::InputDef{123, InputMapping::InputDef::InputType::BUTTON},
+            InputMapping::InputDef{987, InputMapping::InputDef::InputType::AXIS_POS},
+            InputMapping::InputDef{191, InputMapping::InputDef::InputType::AXIS_NEG}
+        },
+        true
+    };
+    inputMapping.set_button(mappedKey2, combo2);
+    const DreamcastKey mappedKey3 = DreamcastKey::DC_BTN_C;
+    const InputMapping::ButtonCombo combo3{
+        InputMapping::InputSet{
+            InputMapping::InputDef{987, InputMapping::InputDef::InputType::AXIS_POS},
+            InputMapping::InputDef{123, InputMapping::InputDef::InputType::BUTTON},
+            InputMapping::InputDef{191, InputMapping::InputDef::InputType::AXIS_NEG}
+        },
+        true
+    };
+    inputMapping.set_button(mappedKey3, combo3);
+
+    // Act
+    const InputMapping::ButtonCombo retrievedCombo1 = inputMapping.get_button_combo(0, mappedKey1);
+    const InputMapping::ButtonCombo retrievedCombo2 = inputMapping.get_button_combo(0, mappedKey2);
+    const InputMapping::ButtonCombo retrievedCombo3 = inputMapping.get_button_combo(0, mappedKey3);
+
+    // Assert
+    EXPECT_EQ(retrievedCombo1, combo1);
+    EXPECT_EQ(retrievedCombo2, combo2);
+    EXPECT_EQ(retrievedCombo3, combo3);
+}

--- a/tests/src/test_stubs.cpp
+++ b/tests/src/test_stubs.cpp
@@ -18,5 +18,9 @@ void os_RunInstance(int argc, const char *argv[])
 void os_SetThreadName(const char *name)
 {
 }
+const char *getThreadName()
+{
+	return "threadname";
+}
 #endif
 #endif

--- a/tests/src/util/PeriodicThreadTest.cpp
+++ b/tests/src/util/PeriodicThreadTest.cpp
@@ -2,6 +2,8 @@
 #include "util/periodic_thread.h"
 #include <atomic>
 
+#include "test_utils.h"
+
 class PeriodicThreadTest : public ::testing::Test
 {
 };

--- a/tests/src/util/TsQueueTest.cpp
+++ b/tests/src/util/TsQueueTest.cpp
@@ -3,6 +3,8 @@
 #include <atomic>
 #include <future>
 
+#include "test_utils.h"
+
 class TsQueueTest : public ::testing::Test
 {
 };

--- a/tests/src/util/TsQueueTest.cpp
+++ b/tests/src/util/TsQueueTest.cpp
@@ -85,7 +85,7 @@ TEST_F(TsQueueTest, Class)
 	TsQueue<T3> q3;
 	q3.push(T3("pi"));
 	T3 r3 = q3.pop();
-	ASSERT_EQ("pi", r3.s);
+	ASSERT_EQ(std::string("pi"), r3.s);
 }
 
 TEST_F(TsQueueTest, Clear)

--- a/tests/src/util/WorkerThreadTest.cpp
+++ b/tests/src/util/WorkerThreadTest.cpp
@@ -3,6 +3,8 @@
 #include <atomic>
 #include <future>
 
+#include "test_utils.h"
+
 class WorkerThreadTest : public ::testing::Test
 {
 };


### PR DESCRIPTION
This feature is intended for use with native DC controllers, to allow multi button binds to EMU buttons when extra keys are not physically available.

Changes made:
- Replaced single button input to single key (1:1) mapping with multiple button input to multiple key (many-to-many) mapping.
    - This is achieved by using new `InputDef`, `InputSet`, and `ButtonCombo` structures under the `InputMapping` class
    - Order of inputs are preserved so that sequence may optionally be strictly followed (default is true for strict sequencing)
    - Axis inputs are still 1:1 mapping just to keep things simple for analog input
- Updated mapping file version to 4 and include combos (mappings with more than one button input) in a separate section for backwards compatibility
- Button combos are only allowed for EMU_BUTTONS in the GUI
- When a combo is allowed, GUI waits for up to 5 second for a button combination or until a button is released, whichever comes first
- `DreamLink` devices now implement `L+ & R+ & Start` through this new feature with strict sequence setting disabled. The custom detection built in the `DreamLinkGamepad` class was removed.

When a combo is set in the mapping, a `Sequential` checkbox is provided. This checkbox is checked for any new combos that are added by the user.
![image](https://github.com/user-attachments/assets/ec675a5b-6183-4d95-8338-82b76c587260)

Sample mapping output:
```
[analog]
bind0 = 0-:btn_analog_left
bind1 = 0+:btn_analog_right
bind2 = 1-:btn_analog_up
bind3 = 1+:btn_analog_down
bind4 = 2-:axis2_left
bind5 = 2+:btn_trigger_left
bind6 = 3-:axis2_up
bind7 = 3+:axis2_down
bind8 = 5+:btn_trigger_right

[combo]
bind0 = 2+,5+,11:btn_menu:0
bind1 = 3,2+:btn_escape:1

[digital]
bind0 = 2:btn_c
bind1 = 1:btn_b
bind10 = 3:btn_x
bind11 = 10:btn_d
bind2 = 0:btn_a
bind3 = 11:btn_start
bind4 = 256:btn_dpad1_up
bind5 = 257:btn_dpad1_down
bind6 = 258:btn_dpad1_left
bind7 = 259:btn_dpad1_right
bind8 = 5:btn_z
bind9 = 4:btn_y

[emulator]
dead_zone = 0
mapping_name = OrangeFox86 DreamPicoPort
rumble_power = 100
saturation = 100
version = 4
```